### PR TITLE
🐛 fix: jpa 의존성 이동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ subprojects {
 
         implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
-        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         runtimeOnly 'com.mysql:mysql-connector-j'
 
         compileOnly 'org.projectlombok:lombok'

--- a/fliqo-member-api/build.gradle
+++ b/fliqo-member-api/build.gradle
@@ -15,4 +15,6 @@ dependencies {
     // 보안
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 }


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 다른 서버에서 불필요한 의존성으로 인해 빌드 및 실행 오류가 발생하는 문제를 해결하기 위해 JPA 의존성을 member 서버로 이동합니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- 루트 `build.gradle`에서 `spring-boot-starter-data-jpa` 의존성 제거
- `member-api` 모듈의 `build.gradle`에 `spring-boot-starter-data-jpa` 의존성 추가

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1.`member-api` 서버를 실행하여 정상적으로 작동하는지 확인합니다.
2.`JPA` 의존성이 필요 없는 다른 서버를 실행하여 정상적으로 시작되는지 확인합니다.

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #
