### PR TITLE
feat: add run scripts and swagger-ui

### DIFF
--- a/dev-script/run-local.sh
+++ b/dev-script/run-local.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------
+# Fliqo 로컬 실행 스크립트 (Git Bash / macOS 전용)
+# - Gateway(8080) / Member API(8081) / Core API(8082)를 순서대로 백그라운드 실행
+# - 프로필(application-<profile>.yml) 지정 가능 (기본: local)
+# - 각 모듈 로그는 ./dev-script/logs/<모듈명>.log 로 분리 저장
+# - 기존 포트 점유 프로세스가 있으면 강제 종료(옵션)
+# - 빌드 수행 (SKIP_BUILD=1 로 건너뛰기 가능) -> 코드를 수정하지 않았을 때 빠르게 재실행하는 용도로 사용
+# ------------------------------------------------------------
+
+set -euo pipefail
+
+# ====== 설정(필요 시 수정) ======
+PROFILE="${1:-local}"            # 사용법: ./run-local.sh [profile]  (기본: local)
+GRADLE="./gradlew"               # Gradle 실행 파일
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$ROOT_DIR/logs"
+KILL_BUSY_PORTS="${KILL_BUSY_PORTS:-1}"  # 1: 포트점유 프로세스 자동 종료, 0: 종료 안 함
+
+# 모듈 실행 순서(의존 관계 고려: core → member → gateway)
+declare -A PORTS=(
+  [fliqo-core-api]=8082
+  [fliqo-member-api]=8081
+  [fliqo-gateway]=8080
+)
+
+# ====== 유틸 함수 ======
+exists() { command -v "$1" >/dev/null 2>&1; }
+
+kill_if_port_busy() {
+  # 포트가 이미 점유되어 있으면 해당 PID를 찾아 종료
+  local port="$1"
+  [[ "$KILL_BUSY_PORTS" != "1" ]] && return 0
+
+  # macOS: lsof 사용 / Git Bash(Windows): netstat + taskkill 사용
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    if exists lsof; then
+      local pid
+      pid=$(lsof -ti tcp:"$port" || true)
+      if [[ -n "${pid:-}" ]]; then
+        echo "포트 ${port} 사용 중 PID(${pid}) 종료"
+        kill -9 $pid || true
+      fi
+    fi
+  else
+    # Git Bash (msys/cygwin)
+    # LISTEN 상태의 PID를 찾아 강제 종료
+    if exists netstat; then
+      # netstat 출력에서 포트 매칭 라인의 마지막 열이 PID
+      local pid
+      pid=$(netstat -ano 2>/dev/null | awk -v p=":$port" '$0 ~ p && $0 ~ /LISTEN/ {print $NF}' | head -n1)
+      if [[ -n "${pid:-}" ]]; then
+        echo "포트 ${port} 사용 중 PID(${pid}) 종료"
+        taskkill //F //PID "$pid" >/dev/null 2>&1 || true
+      fi
+    fi
+  fi
+}
+
+start_module() {
+  # 모듈을 백그라운드로 실행하고 PID/로그 파일을 남긴다
+  local module="$1"
+  local port="$2"
+  local log_file="$LOG_DIR/$module.log"
+  local pid_file="$LOG_DIR/$module.pid"
+
+  echo "🩷 ${module} (port ${port}, profile=${PROFILE}) 시작"
+
+  kill_if_port_busy "$port"
+
+  # nohup으로 백그라운드 실행, 로그 파일 분리 저장
+  nohup "$GRADLE" ":$module:bootRun" \
+    --args="--spring.profiles.active=$PROFILE" \
+    >"$log_file" 2>&1 &
+
+  # PID 기록
+  echo $! > "$pid_file"
+  echo "   ↳ 로그: $log_file / PID: $(cat "$pid_file")"
+}
+
+# ====== 준비 작업 ======
+mkdir -p "$LOG_DIR"
+
+if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
+  echo "빌드 실행 중… (테스트 스킵: -x test)"
+  "$GRADLE" clean build -x test
+else
+  echo "빌드 스킵(SKIP_BUILD=1)"
+fi
+
+# ====== 모듈 실행(core → member → gateway) ======
+start_module "fliqo-core-api"   "${PORTS[fliqo-core-api]}"
+start_module "fliqo-member-api" "${PORTS[fliqo-member-api]}"
+start_module "fliqo-gateway"    "${PORTS[fliqo-gateway]}"
+
+echo ""
+echo "모두 백그라운드 실행 완료"
+echo "로그 디렉토리: $LOG_DIR"
+echo "💚 종료하는 쉘 실행: ./dev-script/stop-local.sh"
+echo ""
+echo "※ 참고"
+echo "- 프로필 변경: ./dev-script/run-local.sh dev"
+echo "- 빌드 생략(코드 수정하지 않았을 때 빠르게 재실행):   SKIP_BUILD=1 ./dev-script/run-local.sh"
+echo "- 포트 점유 종료 끄기: KILL_BUSY_PORTS=0 ./dev-script/run-local.sh"

--- a/dev-script/stop-local.sh
+++ b/dev-script/stop-local.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# ------------------------------------------------------------
+# Fliqo 로컬 종료 스크립트 (Git Bash / macOS 전용)
+# - run-local.sh가 남긴 ./dev-script/logs/*.pid 파일을 읽어 프로세스 종료
+# - 안전하게 종료 후 PID 파일 정리
+# ------------------------------------------------------------
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$ROOT_DIR/logs"
+
+if ! ls "$LOG_DIR"/*.pid >/dev/null 2>&1; then
+  echo "종료할 PID 파일이 없습니다. ($LOG_DIR/*.pid)"
+  exit 0
+fi
+
+for pid_file in "$LOG_DIR"/*.pid; do
+  [[ -f "$pid_file" ]] || continue
+  module="$(basename "$pid_file" .pid)"
+  pid="$(cat "$pid_file" 2>/dev/null || true)"
+
+  if [[ -n "${pid:-}" ]]; then
+    echo "🔻 종료: ${module} (PID $pid)"
+    # 우선 정상 종료 시도
+    kill "$pid" >/dev/null 2>&1 || true
+    # 잠깐 대기 후 여전히 살아 있으면 강제 종료
+    sleep 1
+    if ps -p "$pid" >/dev/null 2>&1; then
+      echo "   ↳ 강제 종료(SIGKILL)"
+      kill -9 "$pid" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  rm -f "$pid_file"
+done
+
+echo "모든 모듈 종료 완료"

--- a/fliqo-core-api/build.gradle
+++ b/fliqo-core-api/build.gradle
@@ -2,5 +2,7 @@ dependencies {
     implementation project(':fliqo-common')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 }

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/CompetitorController.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/CompetitorController.java
@@ -1,0 +1,94 @@
+package com.fliqo.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fliqo.controller.dto.response.competitor.CompetitorBrandsResponse;
+import com.fliqo.controller.dto.response.competitor.CompetitorListResponse;
+import com.fliqo.controller.dto.response.competitor.CompetitorMapResponse;
+import com.fliqo.controller.dto.response.competitor.CompetitorPriceIndexResponse;
+import com.fliqo.controller.dto.response.competitor.CompetitorSummaryResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/market/competitors")
+@Tag(name = "Competitors", description = "경쟁 분석")
+public class CompetitorController {
+
+    @Operation(summary = "경쟁점 요약 조회")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CompetitorSummaryResponse.class)))
+    @GetMapping(value = "/summary", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CompetitorSummaryResponse> getSummary(
+            @RequestHeader(name = "Authorization", required = true) String authorization,
+            @RequestParam(name = "radius") Integer radius,
+            @RequestParam(name = "period") String period) {
+        return ResponseEntity.ok(CompetitorSummaryResponse.sample());
+    }
+
+    @Operation(summary = "브랜드 점유율 조회")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CompetitorBrandsResponse.class)))
+    @GetMapping(value = "/brands", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CompetitorBrandsResponse> getBrands(
+            @RequestHeader(name = "Authorization", required = true) String authorization) {
+        return ResponseEntity.ok(CompetitorBrandsResponse.sample());
+    }
+
+    @Operation(summary = "가격 지수 조회")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CompetitorPriceIndexResponse.class)))
+    @GetMapping(value = "/price-index", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CompetitorPriceIndexResponse> getPriceIndex(
+            @RequestHeader(name = "Authorization", required = true) String authorization) {
+        return ResponseEntity.ok(CompetitorPriceIndexResponse.sample());
+    }
+
+    @Operation(summary = "경쟁점 분포 조회")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CompetitorMapResponse.class)))
+    @GetMapping(value = "/map", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CompetitorMapResponse> getMap(
+            @RequestHeader(name = "Authorization", required = true) String authorization) {
+        return ResponseEntity.ok(CompetitorMapResponse.sample());
+    }
+
+    @Operation(summary = "경쟁점 상세 리스트 조회")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CompetitorListResponse.class)))
+    @GetMapping(value = "/list", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CompetitorListResponse> getList(
+            @RequestHeader(name = "Authorization", required = true) String authorization) {
+        return ResponseEntity.ok(CompetitorListResponse.sample());
+    }
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/FootfallController.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/FootfallController.java
@@ -1,0 +1,83 @@
+package com.fliqo.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fliqo.controller.dto.response.footfall.FootfallDistributionResponse;
+import com.fliqo.controller.dto.response.footfall.FootfallFactorsResponse;
+import com.fliqo.controller.dto.response.footfall.FootfallForecastResponse;
+import com.fliqo.controller.dto.response.footfall.FootfallSummaryResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/market/footfall")
+@Tag(name = "Footfall", description = "유동인구 분석")
+public class FootfallController {
+
+    @Operation(summary = "유동인구 요약 조회")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FootfallSummaryResponse.class)))
+    @GetMapping(value = "/summary", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<FootfallSummaryResponse> getSummary(
+            @RequestHeader(name = "Authorization", required = true) String authorization,
+            @RequestParam(name = "store_id") String storeId,
+            @RequestParam(name = "from") String from,
+            @RequestParam(name = "to") String to,
+            @RequestParam(name = "radius") Integer radius) {
+        return ResponseEntity.ok(FootfallSummaryResponse.sample(storeId, from, to));
+    }
+
+    @Operation(summary = "요일/시간대 분포 조회")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FootfallDistributionResponse.class)))
+    @GetMapping(value = "/distribution", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<FootfallDistributionResponse> getDistribution(
+            @RequestHeader(name = "Authorization", required = true) String authorization,
+            @RequestParam(name = "group_by") String groupBy) {
+        return ResponseEntity.ok(FootfallDistributionResponse.sample());
+    }
+
+    @Operation(summary = "유동 변화 요인 조회")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FootfallFactorsResponse.class)))
+    @GetMapping(value = "/factors", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<FootfallFactorsResponse> getFactors(
+            @RequestHeader(name = "Authorization", required = true) String authorization) {
+        return ResponseEntity.ok(FootfallFactorsResponse.sample());
+    }
+
+    @Operation(summary = "유동 예측 조회")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FootfallForecastResponse.class)))
+    @GetMapping(value = "/forecast", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<FootfallForecastResponse> getForecast(
+            @RequestHeader(name = "Authorization", required = true) String authorization) {
+        return ResponseEntity.ok(FootfallForecastResponse.sample());
+    }
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/MarketOverviewController.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/MarketOverviewController.java
@@ -1,0 +1,42 @@
+package com.fliqo.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fliqo.controller.dto.response.market.MarketOverviewResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/market")
+@Tag(name = "Market Overview", description = "상권 개요/KPI")
+public class MarketOverviewController {
+
+    @Operation(summary = "상권 KPI 조회", description = "매장 반경 기준 상권 KPI 요약")
+    @ApiResponse(
+            responseCode = "200",
+            description = "성공",
+            content =
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = MarketOverviewResponse.class)))
+    @GetMapping(value = "/overview", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<MarketOverviewResponse> getOverview(
+            @RequestHeader(name = "Authorization", required = true) String authorization,
+            @RequestParam(name = "store_id") String storeId,
+            @RequestParam(name = "from") String from,
+            @RequestParam(name = "to") String to,
+            @RequestParam(name = "radius") Integer radius) {
+        MarketOverviewResponse response = MarketOverviewResponse.sample(storeId, from, to, radius);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/competitor/CompetitorBrandsResponse.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/competitor/CompetitorBrandsResponse.java
@@ -1,0 +1,18 @@
+package com.fliqo.controller.dto.response.competitor;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "브랜드 점유율 응답")
+public record CompetitorBrandsResponse(List<Brand> brands) {
+    public static CompetitorBrandsResponse sample() {
+        return new CompetitorBrandsResponse(
+                List.of(
+                        new Brand("스타벅스", 0.33),
+                        new Brand("투썸플레이스", 0.22),
+                        new Brand("이디야", 0.15)));
+    }
+
+    public record Brand(String name, double share) {}
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/competitor/CompetitorListResponse.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/competitor/CompetitorListResponse.java
@@ -1,0 +1,18 @@
+package com.fliqo.controller.dto.response.competitor;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "경쟁점 리스트 응답")
+public record CompetitorListResponse(List<Item> list) {
+    public static CompetitorListResponse sample() {
+        return new CompetitorListResponse(
+                List.of(
+                        new Item("스타벅스 안산점", 4.3, 150),
+                        new Item("투썸플레이스", 4.1, 230),
+                        new Item("이디야커피", 4.2, 380)));
+    }
+
+    public record Item(String name, double rating, int distance) {}
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/competitor/CompetitorMapResponse.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/competitor/CompetitorMapResponse.java
@@ -1,0 +1,17 @@
+package com.fliqo.controller.dto.response.competitor;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "경쟁점 분포 응답")
+public record CompetitorMapResponse(List<Item> competitors) {
+    public static CompetitorMapResponse sample() {
+        return new CompetitorMapResponse(
+                List.of(
+                        new Item("스타벅스 안산점", 37.123, 126.987, 4.3, 150),
+                        new Item("투썸플레이스", 37.125, 126.990, 4.1, 230)));
+    }
+
+    public record Item(String name, double lat, double lng, double rating, int distance) {}
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/competitor/CompetitorPriceIndexResponse.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/competitor/CompetitorPriceIndexResponse.java
@@ -1,0 +1,12 @@
+package com.fliqo.controller.dto.response.competitor;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "가격 지수 응답")
+public record CompetitorPriceIndexResponse(Index index) {
+    public static CompetitorPriceIndexResponse sample() {
+        return new CompetitorPriceIndexResponse(new Index("아메리카노", 4100, 4000, 1.03));
+    }
+
+    public record Index(String base_item, int avg_price, int ref_price, double price_index) {}
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/competitor/CompetitorSummaryResponse.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/competitor/CompetitorSummaryResponse.java
@@ -1,0 +1,14 @@
+package com.fliqo.controller.dto.response.competitor;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "경쟁점 요약 응답")
+public record CompetitorSummaryResponse(Summary summary) {
+    public static CompetitorSummaryResponse sample() {
+        return new CompetitorSummaryResponse(new Summary(12, 320, new TopBrandShare("스타벅스", 0.33)));
+    }
+
+    public record Summary(int total, int avg_distance, TopBrandShare top_brand_share) {}
+
+    public record TopBrandShare(String brand, double share) {}
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/footfall/FootfallDistributionResponse.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/footfall/FootfallDistributionResponse.java
@@ -1,0 +1,18 @@
+package com.fliqo.controller.dto.response.footfall;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유동인구 분포 응답")
+public record FootfallDistributionResponse(List<Weekday> weekday, List<Hour> hour) {
+    public static FootfallDistributionResponse sample() {
+        return new FootfallDistributionResponse(
+                List.of(new Weekday("Mon", 3100), new Weekday("Sat", 4100)),
+                List.of(new Hour("14", 1200), new Hour("15", 1300)));
+    }
+
+    public record Weekday(String day, int avg) {}
+
+    public record Hour(String hour, int avg) {}
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/footfall/FootfallFactorsResponse.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/footfall/FootfallFactorsResponse.java
@@ -1,0 +1,18 @@
+package com.fliqo.controller.dto.response.footfall;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유동 변화 요인 응답")
+public record FootfallFactorsResponse(List<Factor> factors) {
+    public static FootfallFactorsResponse sample() {
+        return new FootfallFactorsResponse(
+                List.of(
+                        new Factor("강수량", "negative"),
+                        new Factor("기온", "u-shape"),
+                        new Factor("프로모션", "positive")));
+    }
+
+    public record Factor(String name, String correlation) {}
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/footfall/FootfallForecastResponse.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/footfall/FootfallForecastResponse.java
@@ -1,0 +1,16 @@
+package com.fliqo.controller.dto.response.footfall;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유동 예측 응답")
+public record FootfallForecastResponse(List<Item> forecast, String model) {
+    public static FootfallForecastResponse sample() {
+        return new FootfallForecastResponse(
+                List.of(new Item("2025-09-18", 3100), new Item("2025-09-19", 3250)),
+                "Prophet/LSTM");
+    }
+
+    public record Item(String date, int expected) {}
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/footfall/FootfallSummaryResponse.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/footfall/FootfallSummaryResponse.java
@@ -1,0 +1,16 @@
+package com.fliqo.controller.dto.response.footfall;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "유동인구 요약 응답")
+public record FootfallSummaryResponse(
+        Meta meta, int avg_daily, Delta delta, String peak_time, String low_time) {
+    public static FootfallSummaryResponse sample(String storeId, String from, String to) {
+        return new FootfallSummaryResponse(
+                new Meta(storeId, from + " ~ " + to), 3247, new Delta("+12%"), "14–16시", "10–11시");
+    }
+
+    public record Meta(String store_id, String period) {}
+
+    public record Delta(String week_over_week) {}
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/market/MarketOverviewResponse.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/dto/response/market/MarketOverviewResponse.java
@@ -1,0 +1,39 @@
+package com.fliqo.controller.dto.response.market;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상권 KPI 개요 응답")
+public record MarketOverviewResponse(
+        Meta meta, Kpis kpis, List<Competitor> competitors, List<Insight> insights) {
+
+    public static MarketOverviewResponse sample(
+            String storeId, String from, String to, Integer radius) {
+        return new MarketOverviewResponse(
+                new Meta(storeId, from, to, radius),
+                new Kpis(3247, "+12%", 87, "+5", List.of(new Audience("20대 여성", 0.38))),
+                List.of(
+                        new Competitor("스타벅스 안산점", 150),
+                        new Competitor("투썸플레이스", 230),
+                        new Competitor("이디야커피", 380)),
+                List.of(
+                        new Insight("opportunity", "14–16시 유동인구 25% 증가 → 디저트 프로모션 고려"),
+                        new Insight("risk", "인근 브랜드 신메뉴 출시로 20대 고객 이탈 가능성")));
+    }
+
+    public record Meta(String store_id, String from, String to, Integer radius) {}
+
+    public record Kpis(
+            int avg_footfall,
+            String footfall_change,
+            int market_index,
+            String market_index_change,
+            List<Audience> top_audience) {}
+
+    public record Audience(String segment, double ratio) {}
+
+    public record Competitor(String name, int distance) {}
+
+    public record Insight(String type, String message) {}
+}

--- a/fliqo-core-api/src/main/resources/application.yml
+++ b/fliqo-core-api/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+server:
+  port: 8082
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: method


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- core-api 모듈에 Swagger UI를 적용하고, 전체 모듈을 로컬에서 쉽게 실행/종료할 수 있는 `dev-script`(`run-local.sh`, `stop-local.sh`)를 추가

📍 참고:  
- 현재 Swagger UI에는 API 목록만 노출됩니다.  
- 실제 실행 로직(Service, Repository 연동)은 추후 구현 예정입니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- `dev-script/run-local.sh`, `dev-script/stop-local.sh` 작성
- core-api 모듈에 Swagger UI 적용 (springdoc-openapi 설정)
- core-api 기본 컨트롤러 및 DTO 추가
- core-api `application.yml` 생성 및 Swagger 설정 반영

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. `./dev-script/run-local.sh` 실행 시 core-api(8082), member-api(8081), gateway(8080) 정상 기동 확인
    - 팀 노션 [기술아카이빙 자료](https://www.notion.so/Fliqo-25ec877718bb8007b54dd3efe9c4971b?p=277c877718bb80f6a019ee923214d35d&pm=s)(팀 권한 있는 사람만 접근 가능) 참고 
2. 브라우저에서 `http://localhost:8082/swagger-ui.html` 접속
3. Swagger UI 화면에서 상권분석 API 엔드포인트 노출 확인

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #14 #13 
