### PR TITLE
chore(dev-script): run/stop 스크립트 macOS Bash 호환성 개선

### DIFF
--- a/dev-script/run-local.sh
+++ b/dev-script/run-local.sh
@@ -1,54 +1,56 @@
 #!/usr/bin/env bash
 # ------------------------------------------------------------
-# Fliqo 로컬 실행 스크립트 (Git Bash / macOS 전용)
-# - Gateway(8080) / Member API(8081) / Core API(8082)를 순서대로 백그라운드 실행
-# - 프로필(application-<profile>.yml) 지정 가능 (기본: local)
-# - 각 모듈 로그는 ./dev-script/logs/<모듈명>.log 로 분리 저장
-# - 기존 포트 점유 프로세스가 있으면 강제 종료(옵션)
-# - 빌드 수행 (SKIP_BUILD=1 로 건너뛰기 가능) -> 코드를 수정하지 않았을 때 빠르게 재실행하는 용도로 사용
+# Fliqo 로컬 실행 스크립트 (Git Bash / macOS 공통)
+# - Gateway(8080) / Member API(8081) / Core API(8082) 순서 실행
+# - profile 인자 (기본: local), SKIP_BUILD=1 로 빌드 생략 가능
+# - 포트 점유 프로세스 자동 종료(KILL_BUSY_PORTS=1)
+# - 로그/ PID 분리 저장
 # ------------------------------------------------------------
 
 set -euo pipefail
 
-# ====== 설정(필요 시 수정) ======
-PROFILE="${1:-local}"            # 사용법: ./run-local.sh [profile]  (기본: local)
-GRADLE="./gradlew"               # Gradle 실행 파일
-ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
-LOG_DIR="$ROOT_DIR/logs"
-KILL_BUSY_PORTS="${KILL_BUSY_PORTS:-1}"  # 1: 포트점유 프로세스 자동 종료, 0: 종료 안 함
+# ====== 설정 ======
+PROFILE="${1:-local}"           # 사용법: ./run-local.sh [profile]
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"   # gradlew가 루트에 있다고 가정
+GRADLE="$REPO_ROOT/gradlew"
+LOG_DIR="$SCRIPT_DIR/logs"
+KILL_BUSY_PORTS="${KILL_BUSY_PORTS:-1}"     # 1: 포트점유 프로세스 종료
 
-# 모듈 실행 순서(의존 관계 고려: core → member → gateway)
-declare -A PORTS=(
-  [fliqo-core-api]=8082
-  [fliqo-member-api]=8081
-  [fliqo-gateway]=8080
-)
+# 모듈/포트 정의 (연관배열 없이 Bash 3.2 호환)
+MODULES=("fliqo-core-api" "fliqo-member-api" "fliqo-gateway")
+port_of() {
+  case "$1" in
+    fliqo-core-api) echo 8082 ;;
+    fliqo-member-api) echo 8081 ;;
+    fliqo-gateway) echo 8080 ;;
+    *) echo "0" ;;
+  esac
+}
 
-# ====== 유틸 함수 ======
+# ====== 유틸 ======
 exists() { command -v "$1" >/dev/null 2>&1; }
 
 kill_if_port_busy() {
-  # 포트가 이미 점유되어 있으면 해당 PID를 찾아 종료
   local port="$1"
   [[ "$KILL_BUSY_PORTS" != "1" ]] && return 0
 
-  # macOS: lsof 사용 / Git Bash(Windows): netstat + taskkill 사용
-  if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS: lsof, Git Bash(Windows): netstat+taskkill
+  if [[ "${OSTYPE:-}" == darwin* ]]; then
     if exists lsof; then
       local pid
-      pid=$(lsof -ti tcp:"$port" || true)
+      pid="$(lsof -ti tcp:"$port" || true)"
       if [[ -n "${pid:-}" ]]; then
         echo "포트 ${port} 사용 중 PID(${pid}) 종료"
         kill -9 $pid || true
       fi
     fi
   else
-    # Git Bash (msys/cygwin)
-    # LISTEN 상태의 PID를 찾아 강제 종료
+    # Git Bash(msys/cygwin)
     if exists netstat; then
-      # netstat 출력에서 포트 매칭 라인의 마지막 열이 PID
+      # LISTEN/ LISTENING 모두 매칭되도록 LISTEN 사용(서브스트링)
       local pid
-      pid=$(netstat -ano 2>/dev/null | awk -v p=":$port" '$0 ~ p && $0 ~ /LISTEN/ {print $NF}' | head -n1)
+      pid="$(netstat -ano 2>/dev/null | awk -v p=":$port" '$0 ~ p && $0 ~ /LISTEN/ {print $NF}' | head -n1)"
       if [[ -n "${pid:-}" ]]; then
         echo "포트 ${port} 사용 중 PID(${pid}) 종료"
         taskkill //F //PID "$pid" >/dev/null 2>&1 || true
@@ -58,7 +60,6 @@ kill_if_port_busy() {
 }
 
 start_module() {
-  # 모듈을 백그라운드로 실행하고 PID/로그 파일을 남긴다
   local module="$1"
   local port="$2"
   local log_file="$LOG_DIR/$module.log"
@@ -68,30 +69,28 @@ start_module() {
 
   kill_if_port_busy "$port"
 
-  # nohup으로 백그라운드 실행, 로그 파일 분리 저장
-  nohup "$GRADLE" ":$module:bootRun" \
-    --args="--spring.profiles.active=$PROFILE" \
-    >"$log_file" 2>&1 &
+  # gradlew는 리포트 루트에서 실행
+  ( cd "$REPO_ROOT" && \
+    nohup "$GRADLE" ":$module:bootRun" --args="--spring.profiles.active=$PROFILE" \
+    >"$log_file" 2>&1 & echo $! > "$pid_file" )
 
-  # PID 기록
-  echo $! > "$pid_file"
   echo "   ↳ 로그: $log_file / PID: $(cat "$pid_file")"
 }
 
-# ====== 준비 작업 ======
+# ====== 준비 ======
 mkdir -p "$LOG_DIR"
 
 if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
   echo "빌드 실행 중… (테스트 스킵: -x test)"
-  "$GRADLE" clean build -x test
+  ( cd "$REPO_ROOT" && "$GRADLE" clean build -x test )
 else
   echo "빌드 스킵(SKIP_BUILD=1)"
 fi
 
-# ====== 모듈 실행(core → member → gateway) ======
-start_module "fliqo-core-api"   "${PORTS[fliqo-core-api]}"
-start_module "fliqo-member-api" "${PORTS[fliqo-member-api]}"
-start_module "fliqo-gateway"    "${PORTS[fliqo-gateway]}"
+# ====== 모듈 실행: core → member → gateway ======
+for m in "${MODULES[@]}"; do
+  start_module "$m" "$(port_of "$m")"
+done
 
 echo ""
 echo "모두 백그라운드 실행 완료"

--- a/dev-script/stop-local.sh
+++ b/dev-script/stop-local.sh
@@ -7,8 +7,8 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
-LOG_DIR="$ROOT_DIR/logs"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_DIR="$SCRIPT_DIR/logs"
 
 if ! ls "$LOG_DIR"/*.pid >/dev/null 2>&1; then
   echo "종료할 PID 파일이 없습니다. ($LOG_DIR/*.pid)"
@@ -22,9 +22,8 @@ for pid_file in "$LOG_DIR"/*.pid; do
 
   if [[ -n "${pid:-}" ]]; then
     echo "🔻 종료: ${module} (PID $pid)"
-    # 우선 정상 종료 시도
+    # 정상 종료 시도
     kill "$pid" >/dev/null 2>&1 || true
-    # 잠깐 대기 후 여전히 살아 있으면 강제 종료
     sleep 1
     if ps -p "$pid" >/dev/null 2>&1; then
       echo "   ↳ 강제 종료(SIGKILL)"
@@ -36,3 +35,4 @@ for pid_file in "$LOG_DIR"/*.pid; do
 done
 
 echo "모든 모듈 종료 완료"
+echo "💚 로그 디렉토리: $LOG_DIR"


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- run-local.sh / stop-local.sh를 macOS 기본 Bash(3.2) + Git Bash(Windows) 양쪽 모두에서 동작하도록 호환성 개선

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- `run-local.sh`
  - `declare -A`(연관 배열) → macOS Bash 3.2 호환을 위해 `case` 기반 함수(`port_of`)로 대체
  - `gradlew` 경로를 `dev-script/` 기준이 아닌 **프로젝트 루트**에서 실행하도록 수정
  - 모듈 실행 순서/로그 저장 로직은 동일하게 유지
- `stop-local.sh`
  - `SCRIPT_DIR` / `LOG_DIR` 변수 체계 run 스크립트와 통일
  - `.pid` 파일 기준으로 안전 종료 후 강제 종료(SIGKILL) 로직 유지
  - 종료 후 로그 디렉토리 위치 출력 추가

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. macOS 기본 Bash(3.2) 환경에서 `./dev-script/run-local.sh` 실행 → core/member/gateway 모두 정상 기동 확인
2. Git Bash(Windows) 환경에서 동일 실행 → 로그 파일(`./dev-script/logs/*.log`)과 PID 파일 생성 확인
3. `./dev-script/stop-local.sh` 실행 → 모든 모듈 프로세스 종료 및 `.pid` 삭제 확인

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #
