### PR TITLE
fix: stop-local.sh 스크립트에 포트 기반 프로세스 종료 기능 추가

### DIFF
--- a/dev-script/stop-local.sh
+++ b/dev-script/stop-local.sh
@@ -10,6 +10,43 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_DIR="$SCRIPT_DIR/logs"
 
+# 포트/모듈 매핑 (run-local.sh와 동일 포트 사용)
+MODULES=("fliqo-core-api" "fliqo-member-api" "fliqo-gateway")
+port_of() {
+  case "$1" in
+    fliqo-core-api) echo 8082 ;;
+    fliqo-member-api) echo 8081 ;;
+    fliqo-gateway) echo 8080 ;;
+    *) echo 0 ;;
+  esac
+}
+
+exists() { command -v "$1" >/dev/null 2>&1; }
+
+kill_by_port() {
+  local port="$1"
+  # macOS: lsof, Git Bash(Windows): netstat+taskkill
+  if [[ "${OSTYPE:-}" == darwin* ]]; then
+    if exists lsof; then
+      local pid
+      pid="$(lsof -ti tcp:"$port" || true)"
+      if [[ -n "${pid:-}" ]]; then
+        echo "   ↳ 포트 ${port} 사용 PID(${pid}) 강제 종료"
+        kill -9 $pid >/dev/null 2>&1 || true
+      fi
+    fi
+  else
+    if exists netstat; then
+      local pid
+      pid="$(netstat -ano 2>/dev/null | awk -v p=":$port" '$0 ~ p && $0 ~ /LISTEN/ {print $NF}' | head -n1)"
+      if [[ -n "${pid:-}" ]]; then
+        echo "   ↳ 포트 ${port} 사용 PID(${pid}) 강제 종료(taskkill)"
+        taskkill //F //PID "$pid" >/dev/null 2>&1 || true
+      fi
+    fi
+  fi
+}
+
 if ! ls "$LOG_DIR"/*.pid >/dev/null 2>&1; then
   echo "종료할 PID 파일이 없습니다. ($LOG_DIR/*.pid)"
   exit 0
@@ -32,6 +69,14 @@ for pid_file in "$LOG_DIR"/*.pid; do
   fi
 
   rm -f "$pid_file"
+done
+
+# 추가 안전장치: 포트 기준으로 잔존 프로세스 종료(Windows 파일 잠김 방지)
+for m in "${MODULES[@]}"; do
+  port="$(port_of "$m")"
+  [[ "$port" == "0" ]] && continue
+  echo "😈 확인: ${m} (port ${port}) 잔존 프로세스 검사"
+  kill_by_port "$port"
 done
 
 echo "모든 모듈 종료 완료"


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- Windows(Git Bash) 환경에서 `gradlew clean` 실패를 유발하던 포트/파일 잠김 문제를 해결하기 위해 `dev-script/stop-local.sh`에 포트 기반 강제 종료 로직을 추가하고, macOS에서도 안전하게 동작하도록 분기 처리

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- `stop-local.sh` 개선
  - 포트 기준 잔존 프로세스 종료 추가: 8080(Gateway), 8081(Member), 8082(Core)
  - OS 분기 처리
    - macOS: `lsof -ti tcp:<port>` → `kill -9`
    - Windows(Git Bash): `netstat -ano` → `taskkill /F /PID`
  - PID 파일이 없거나 오래된 경우에도 포트 잠김 해소
- 로그 메시지 보강: 잔존 프로세스 검사/강제 종료 단계 출력

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 로컬에서 서비스 실행
   ```bash
   ./dev-script/run-local.sh
   ```
2. 종료 스크립트 실행
   ```bash
   ./dev-script/stop-local.sh
   ```
3. 포트 점유 확인 (아래 명령 중 OS에 맞게)
   - Windows(Git Bash):
     ```bash
     netstat -ano | awk '/LISTEN/ && /:(8080|8081|8082) /'
     ```
   - macOS:
     ```bash
     lsof -i :8080 -i :8081 -i :8082
     ```
   - 기대 결과: 8080/8081/8082 포트가 비어 있어야 함
4. 재실행 후 빌드 클린 검증
   ```bash
   ./dev-script/run-local.sh
   ```
   - 기대 결과: `:clean` 단계에서 파일 잠김 오류 없이 정상 빌드 및 기동

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #
