### PR TITLE
gateway swagger group selector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-validation'
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-        implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
         runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/fliqo-gateway/build.gradle
+++ b/fliqo-gateway/build.gradle
@@ -3,7 +3,9 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.13'
 
     implementation'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/fliqo-member-api/build.gradle
+++ b/fliqo-member-api/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     // OAuth2 소셜 로그인 (카카오, 네이버 등)
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+
     // JWT 생성
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- Gateway에서 member-api, core-api를 swagger 통해 드롭 다운 형식으로 볼 수 있다. 

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- fliqo-service-api 루트 gradle에 전역 의존성 `springdoc-openapi-starter-webmvc-ui` 삭제.
- gateway는 webmvc가 아니라 webflux를 사용하기 때문에 루트 gradle에 webmvc-ui가 있을 경우 충돌 발생.
- gateway 의존성 `springdoc-openapi-starter-webflux` 추가.
- member-api build.gradle 'implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13' 추가
- 노션 환경변수 gateway application-local 수정
  - urls 추가 
  - v3/api-docs 라우트 추가  
- swagger-ui에서 health check 경우만 실행 시 값이 나오고 다른 api는 cors로 인해 추후 수정 예정.

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. http://localhost:8080/swagger-ui/index.html 접속
2. 화면 오른쪽 상단에 Select a definition에 드롭다운을 통해 member-api, core-api 선택 가능. 


## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #18 
