### PR TITLE
application.yml 통합 및 Gateway Swagger api 호출

### DIFF
--- a/fliqo-core-api/src/main/java/com/fliqo/controller/CompetitorController.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/CompetitorController.java
@@ -49,7 +49,8 @@ public class CompetitorController {
                             schema = @Schema(implementation = CompetitorBrandsResponse.class)))
     @GetMapping(value = "/brands", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CompetitorBrandsResponse> getBrands(
-            @RequestHeader(name = "Authorization", required = true) String authorization) {
+//            @RequestHeader(name = "Authorization", required = true) String authorization
+    ) {
         return ResponseEntity.ok(CompetitorBrandsResponse.sample());
     }
 

--- a/fliqo-core-api/src/main/resources/application.yml
+++ b/fliqo-core-api/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 server:
   port: 8082
-
+  forward-headers-strategy: framework
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/fliqo-gateway/src/main/resources/application.yml
+++ b/fliqo-gateway/src/main/resources/application.yml
@@ -1,25 +1,119 @@
+# 공통
 server:
   port: 8080
-
 spring:
   application:
     name: fliqo-gateway
-  profiles:
-    default: local
   cloud:
     gateway:
       default-filters:
         - DedupeResponseHeader=Access-Control-Allow-Credentials Access-Control-Allow-Origin
-
 logging:
-  level:
-    org.springframework.cloud.gateway: INFO
-    org.springframework.web.cors: DEBUG
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} - %msg%n"
-
 management:
   endpoints:
     web:
       exposure:
         include: health,info
+---
+# local 전용
+spring:
+  config:
+    activate:
+      on-profile: local
+  cloud:
+    gateway:
+      globalcors:
+        corsConfigurations:
+          '[/**]':
+            allowedOrigins:
+              - "http://localhost:3000"
+#              - "http://localhost:8080"
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - DELETE
+              - OPTIONS
+            allowedHeaders: "*"
+            allowCredentials: true
+            maxAge: 3600
+      routes:
+        - id: member-api
+          uri: http://localhost:8081
+          predicates:
+            - Path=/api/member/**,/api/auth/**
+        - id: core-api
+          uri: http://localhost:8082
+          predicates:
+            - Path=/api/market/**
+        - id: member-api-docs
+          uri: http://localhost:8081
+          predicates:
+            - Path=/v3/api-docs/member
+          filters:
+            - SetPath=/v3/api-docs
+        - id: core-api-docs
+          uri: http://localhost:8082
+          predicates:
+            - Path=/v3/api-docs/core
+          filters:
+            - SetPath=/v3/api-docs
+jwt:
+  secret: ${JWT_SECRET}
+logging:
+  level:
+    org.springframework.cloud.gateway: DEBUG
+    org.springframework.web.cors: DEBUG
+    root: INFO
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+    urls:
+      - name: member-api
+        url: /v3/api-docs/member
+      - name: core-api
+        url: /v3/api-docs/core
+---
+# dev 전용
+spring:
+  config:
+    activate:
+      on-profile: dev
+  cloud:
+    gateway:
+      globalcors:
+        corsConfigurations:
+          '[/**]':
+            allowedOrigins:
+              - "https://www.fliqo.com"
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - DELETE
+              - OPTIONS
+            allowedHeaders:
+              - "Content-Type"
+              - "Authorization"
+              - "Accept"
+              - "X-Requested-With"
+            allowCredentials: true
+            maxAge: 3600
+      routes:
+        - id: member-api
+          uri: http://member-api
+          predicates:
+            - Path=/api/member/**,/api/auth/**
+        - id: core-api
+          uri: http://core-api
+          predicates:
+            - Path=/api/core/**
+jwt:
+  secret: ${JWT_SECRET}
+logging:
+  level:
+    org.springframework.cloud.gateway: INFO
+    org.springframework.web.cors: INFO
+    root: WARN

--- a/fliqo-member-api/src/main/resources/application.yml
+++ b/fliqo-member-api/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server:
   port: 8081
+  forward-headers-strategy: framework
 
 spring:
   profiles:


### PR DESCRIPTION
## 📌 PR 개요

<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->

* Spring Boot 멀티 프로필(`---`)을 활용해 `application.yml`을 공통/로컬/개발로 통합
* Swagger “Try it out”이 항상 **게이트웨이**를 타도록 환경 정비
* API 테스트 편의를 위해 Swagger에서 Authorization 헤더 요구 제거(주석)

## 🔍 변경 사항

<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->

* `application.yml` 단일 파일로 통합: 공통 + `local` + `dev` 프로필 구성
* Gateway: `/v3/api-docs/member`, `/v3/api-docs/core` 프록시 및 Swagger UI 멀티 소스 유지
* `member-api`, `core-api`: `server.forward-headers-strategy: framework` 추가 → 프록시(게이트웨이) 뒤 인지
* Swagger 테스트 편의: `@RequestHeader(name="Authorization")` 주석 처리(해당 엔드포인트)
* 시크릿은 `${JWT_SECRET}` 플레이스홀더 유지(로컬=IntelliJ Env, 서버=SSM)
* 로깅: `dev`는 root=WARN 유지(게이트웨이 관련 INFO만 노출)

## 🧪 테스트 방법

<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->

1. **로컬 실행 준비**

   * IntelliJ Run/Debug Config

     * **Active profiles**: `local`
     * **Environment variables**: `JWT_SECRET=<로컬 값>`
   * Gateway 기동 후 `http://localhost:8080/swagger-ui.html` 접속

2. **Swagger 경로 선택**

   * Swagger UI 좌상단 **API 선택 드롭다운**에서 문서 선택

     * `member-api` 문서 → 게이트웨이 경유
     * `core-api` 문서 → 게이트웨이 경유

3. **Try it out (게이트웨이 경유 확인)**

   * 브라우저 DevTools → **Network** 탭 열기
   * 임의의 엔드포인트 실행 후 **요청 URL이 반드시 `http://localhost:8080/...`(게이트웨이)** 인지 확인
   * CORS/CSRF 오류가 없어야 함

4. **코어 API 테스트 예시**

   * (주석 처리된 엔드포인트 기준) **GET `/api/market/competitors/brands`** 실행
   * 로컬 `local` 프로필 라우팅에 따라 경로가 게이트웨이에서 자동 매핑됨
   * Swagger에서 Try it out 시 **토큰 없이 200 OK** 응답 및 샘플 페이로드 확인

5. **멤버 API 연동 확인(샘플)**

   * `member-api` 문서에서 공개 엔드포인트 하나 실행(예: 헬스/공개 조회)
   * 요청이 **게이트웨이 경유(8080)** 로만 나가는지, 응답 200 확인


## 📎 참고 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->

Ref: #25 

---
