### PR TITLE
Member Service, Controller 단 리팩토링

### DIFF
--- a/fliqo-core-api/src/main/java/com/fliqo/controller/CompetitorController.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/CompetitorController.java
@@ -49,8 +49,9 @@ public class CompetitorController {
                             schema = @Schema(implementation = CompetitorBrandsResponse.class)))
     @GetMapping(value = "/brands", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CompetitorBrandsResponse> getBrands(
-//            @RequestHeader(name = "Authorization", required = true) String authorization
-    ) {
+            //            @RequestHeader(name = "Authorization", required = true) String
+            // authorization
+            ) {
         return ResponseEntity.ok(CompetitorBrandsResponse.sample());
     }
 

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -3,10 +3,8 @@ package com.fliqo.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.fliqo.config.JwtProperties;
 import com.fliqo.controller.dto.request.*;
 import com.fliqo.controller.dto.response.*;
-import com.fliqo.service.JwtService;
 import com.fliqo.service.MemberService;
 import com.fliqo.service.PhoneVerificationService;
 import com.fliqo.service.dto.request.EmailCheckCommand;
@@ -29,8 +27,6 @@ public class MemberController {
     private final MemberService memberService;
     private final PhoneVerificationService phoneVerificationService;
     private final MemberPolicyValidator memberPolicyValidator;
-    private final JwtService jwtService;
-    private final JwtProperties jwtProperties;
 
     @PostMapping("/email-check")
     public ResponseEntity<ApiResponse<EmailCheckResponse>> check(
@@ -91,9 +87,7 @@ public class MemberController {
 
     @PostMapping("/login")
     public ResponseEntity<TokenResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto) {
-        String accessToken = memberService.login(requestDto.email(), requestDto.password());
-        long expirationSeconds = jwtProperties.getAccessMin() * 60;
-
-        return ResponseEntity.ok(TokenResponseDto.of(accessToken, expirationSeconds));
+        TokenResponseDto response = memberService.login(requestDto.email(), requestDto.password());
+        return ResponseEntity.ok(response);
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -30,64 +30,67 @@ public class MemberController {
 
     @PostMapping("/email-check")
     public ResponseEntity<ApiResponse<EmailCheckResponse>> check(
-            @Valid @RequestBody EmailCheckRequest req) {
-        EmailCheckCommand cmd = new EmailCheckCommand(req.email().toLowerCase());
-        EmailCheckResult result = memberService.checkEmail(cmd);
+            @Valid @RequestBody EmailCheckRequest emailCheckRequest) {
+        EmailCheckCommand emailCheckCmd = new EmailCheckCommand(emailCheckRequest.email().toLowerCase());
+        EmailCheckResult emailCheckResult = memberService.checkEmail(emailCheckCmd);
 
-        EmailCheckResponse resp = EmailCheckResponse.of(result.exists());
-        return ResponseEntity.ok(ApiResponse.ok(resp));
+        EmailCheckResponse emailCheckResponse = EmailCheckResponse.of(emailCheckResult.exists());
+        return ResponseEntity.ok(ApiResponse.ok(emailCheckResponse));
     }
 
     @PostMapping("/phone/verify/request")
     public ResponseEntity<ApiResponse<PhoneVerifyRequestResponse>> phoneVerifyRequest(
-            @Valid @RequestBody PhoneVerifyStartRequest req) {
-        PhoneVerificationStartResult res =
-                phoneVerificationService.start(PhoneVerificationStartCommand.of(req.phoneNumber()));
+            @Valid @RequestBody PhoneVerifyStartRequest phoneVerifyStartRequest) {
+        PhoneVerificationStartResult phoneVerificationStartResult =
+                phoneVerificationService.start(PhoneVerificationStartCommand.of(phoneVerifyStartRequest.phoneNumber()));
         return ResponseEntity.ok(
                 ApiResponse.ok(
                         PhoneVerifyRequestResponse.of(
-                                res.verificationId(), res.expiresInMinutes())));
+                                phoneVerificationStartResult.verificationId(),
+                                phoneVerificationStartResult.expiresInMinutes())));
     }
 
     @PostMapping("/phone/verify/confirm")
     public ResponseEntity<ApiResponse<PhoneVerifyConfirmResponse>> phoneVerifyConfirm(
-            @Valid @RequestBody PhoneVerifyConfirmRequest req) {
-        PhoneVerificationConfirmResult res =
+            @Valid @RequestBody PhoneVerifyConfirmRequest phoneVerifyConfirmRequset) {
+        PhoneVerificationConfirmResult phoneVerificationConfirmResult =
                 phoneVerificationService.confirm(
-                        PhoneVerificationConfirmCommand.of(req.verificationId(), req.code()));
+                        PhoneVerificationConfirmCommand.of(
+                                phoneVerifyConfirmRequset.verificationId(),
+                                phoneVerifyConfirmRequset.code()));
 
         return ResponseEntity.ok(
-                ApiResponse.ok(PhoneVerifyConfirmResponse.of(res.verificationToken())));
+                ApiResponse.ok(PhoneVerifyConfirmResponse.of(phoneVerificationConfirmResult.verificationToken())));
     }
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(
-            @Valid @RequestBody SignupRequest req) {
-        memberPolicyValidator.validateOrThrow(req.password(), req.passwordConfirm());
+            @Valid @RequestBody SignupRequest signupRequest) {
+        memberPolicyValidator.validateOrThrow(signupRequest.password(), signupRequest.passwordConfirm());
 
-        SignupResult result =
+        SignupResult signupResult =
                 memberService.signup(
                         SignupCommand.builder()
-                                .email(req.email())
-                                .rawPassword(req.password())
-                                .name(req.name())
-                                .phoneNumber(req.phoneNumber())
-                                .phoneVerificationToken(req.phoneVerificationToken())
+                                .email(signupRequest.email())
+                                .rawPassword(signupRequest.password())
+                                .name(signupRequest.name())
+                                .phoneNumber(signupRequest.phoneNumber())
+                                .phoneVerificationToken(signupRequest.phoneVerificationToken())
                                 .build());
 
         return ResponseEntity.ok(
                 ApiResponse.ok(
                         SignupResponse.builder()
-                                .memberUuid(result.memberUuid())
-                                .email(result.email())
-                                .name(result.name())
-                                .phoneNumber(result.phoneNumber())
+                                .memberUuid(signupResult.memberUuid())
+                                .email(signupResult.email())
+                                .name(signupResult.name())
+                                .phoneNumber(signupResult.phoneNumber())
                                 .build()));
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto) {
-        TokenResponseDto response = memberService.login(requestDto.email(), requestDto.password());
-        return ResponseEntity.ok(response);
+    public ResponseEntity<TokenResponseDto> login(@Valid @RequestBody LoginRequestDto loginRequestDto) {
+        TokenResponseDto tokenResponseDto = memberService.login(loginRequestDto.email(), loginRequestDto.password());
+        return ResponseEntity.ok(tokenResponseDto);
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -31,8 +31,7 @@ public class MemberController {
     @PostMapping("/email-check")
     public ResponseEntity<ApiResponse<EmailCheckResponse>> check(
             @Valid @RequestBody EmailCheckRequest emailCheckRequest) {
-        EmailCheckCommand emailCheckCmd =
-                new EmailCheckCommand(emailCheckRequest.email().toLowerCase());
+        EmailCheckCommand emailCheckCmd = EmailCheckCommand.of(emailCheckRequest.email());
         EmailCheckResult emailCheckResult = memberService.checkEmail(emailCheckCmd);
 
         EmailCheckResponse emailCheckResponse = EmailCheckResponse.of(emailCheckResult.exists());

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -54,12 +54,12 @@ public class MemberController {
 
     @PostMapping("/phone/verify/confirm")
     public ResponseEntity<ApiResponse<PhoneVerifyConfirmResponse>> phoneVerifyConfirm(
-            @Valid @RequestBody PhoneVerifyConfirmRequest phoneVerifyConfirmRequset) {
+            @Valid @RequestBody PhoneVerifyConfirmRequest phoneVerifyConfirmRequest) {
         PhoneVerificationConfirmResult phoneVerificationConfirmResult =
                 phoneVerificationService.confirm(
                         PhoneVerificationConfirmCommand.of(
-                                phoneVerifyConfirmRequset.verificationId(),
-                                phoneVerifyConfirmRequset.code()));
+                                phoneVerifyConfirmRequest.verificationId(),
+                                phoneVerifyConfirmRequest.code()));
 
         return ResponseEntity.ok(
                 ApiResponse.ok(

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -31,7 +31,8 @@ public class MemberController {
     @PostMapping("/email-check")
     public ResponseEntity<ApiResponse<EmailCheckResponse>> check(
             @Valid @RequestBody EmailCheckRequest emailCheckRequest) {
-        EmailCheckCommand emailCheckCmd = new EmailCheckCommand(emailCheckRequest.email().toLowerCase());
+        EmailCheckCommand emailCheckCmd =
+                new EmailCheckCommand(emailCheckRequest.email().toLowerCase());
         EmailCheckResult emailCheckResult = memberService.checkEmail(emailCheckCmd);
 
         EmailCheckResponse emailCheckResponse = EmailCheckResponse.of(emailCheckResult.exists());
@@ -42,7 +43,8 @@ public class MemberController {
     public ResponseEntity<ApiResponse<PhoneVerifyRequestResponse>> phoneVerifyRequest(
             @Valid @RequestBody PhoneVerifyStartRequest phoneVerifyStartRequest) {
         PhoneVerificationStartResult phoneVerificationStartResult =
-                phoneVerificationService.start(PhoneVerificationStartCommand.of(phoneVerifyStartRequest.phoneNumber()));
+                phoneVerificationService.start(
+                        PhoneVerificationStartCommand.of(phoneVerifyStartRequest.phoneNumber()));
         return ResponseEntity.ok(
                 ApiResponse.ok(
                         PhoneVerifyRequestResponse.of(
@@ -60,13 +62,16 @@ public class MemberController {
                                 phoneVerifyConfirmRequset.code()));
 
         return ResponseEntity.ok(
-                ApiResponse.ok(PhoneVerifyConfirmResponse.of(phoneVerificationConfirmResult.verificationToken())));
+                ApiResponse.ok(
+                        PhoneVerifyConfirmResponse.of(
+                                phoneVerificationConfirmResult.verificationToken())));
     }
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(
             @Valid @RequestBody SignupRequest signupRequest) {
-        memberPolicyValidator.validateOrThrow(signupRequest.password(), signupRequest.passwordConfirm());
+        memberPolicyValidator.validateOrThrow(
+                signupRequest.password(), signupRequest.passwordConfirm());
 
         SignupResult signupResult =
                 memberService.signup(
@@ -89,8 +94,10 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResponseDto> login(@Valid @RequestBody LoginRequestDto loginRequestDto) {
-        TokenResponseDto tokenResponseDto = memberService.login(loginRequestDto.email(), loginRequestDto.password());
+    public ResponseEntity<TokenResponseDto> login(
+            @Valid @RequestBody LoginRequestDto loginRequestDto) {
+        TokenResponseDto tokenResponseDto =
+                memberService.login(loginRequestDto.email(), loginRequestDto.password());
         return ResponseEntity.ok(tokenResponseDto);
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
@@ -35,25 +35,25 @@ public class MemberService {
     private final JwtProperties jwtProperties;
 
     @Transactional(readOnly = true)
-    public EmailCheckResult checkEmail(EmailCheckCommand cmd) {
-        boolean exists = memberRepository.existsByEmail(cmd.email());
+    public EmailCheckResult checkEmail(EmailCheckCommand emailCheckCmd) {
+        boolean exists = memberRepository.existsByEmail(emailCheckCmd.email());
         return new EmailCheckResult(exists);
     }
 
     /**
      * 회원가입을 처리합니다. 이메일 중복 검증, 전화번호 인증 확인, 회원 생성, 인증정보 저장 과정을 거칩니다.
      *
-     * @param cmd 회원가입에 필요한 정보를 담은 커맨드 객체
+     * @param signupCmd 회원가입에 필요한 정보를 담은 커맨드 객체
      * @return 생성된 회원의 정보를 담은 SignupResult
      * @throws IllegalStateException 이메일이 이미 사용 중인 경우
      * @throws IllegalArgumentException 전화번호 인증이 유효하지 않은 경우
      */
     @Transactional
-    public SignupResult signup(SignupCommand cmd) {
-        validateSignupRequest(cmd);
-        PhoneVerification phoneVerification = verifyPhone(cmd);
-        Member member = createMember(cmd);
-        createCredential(member, cmd.rawPassword());
+    public SignupResult signup(SignupCommand signupCmd) {
+        validateSignupRequest(signupCmd);
+        PhoneVerification phoneVerification = verifyPhone(signupCmd);
+        Member member = createMember(signupCmd);
+        createCredential(member, signupCmd.rawPassword());
         phoneVerificationService.consumeToken(phoneVerification);
 
         return buildSignupResult(member);
@@ -62,40 +62,40 @@ public class MemberService {
     /**
      * 회원가입 요청의 유효성을 검증합니다. 이메일 중복 여부를 확인합니다.
      *
-     * @param cmd 회원가입 커맨드 객체
+     * @param signupCmd 회원가입 커맨드 객체
      * @throws IllegalStateException 이메일이 이미 사용 중인 경우
      */
-    private void validateSignupRequest(SignupCommand cmd) {
-        memberPolicyValidator.ensureEmailAvailable(cmd.email());
+    private void validateSignupRequest(SignupCommand signupCmd) {
+        memberPolicyValidator.ensureEmailAvailable(signupCmd.email());
     }
 
     /**
      * 전화번호 인증을 확인합니다. 인증 토큰을 조회하고 전화번호가 일치하는지 검증합니다.
      *
-     * @param cmd 회원가입 커맨드 객체
+     * @param signupCmd 회원가입 커맨드 객체
      * @return 검증된 PhoneVerification 객체
      * @throws IllegalArgumentException 인증 토큰이 유효하지 않거나 전화번호가 일치하지 않는 경우
      */
-    private PhoneVerification verifyPhone(SignupCommand cmd) {
+    private PhoneVerification verifyPhone(SignupCommand signupCmd) {
         PhoneVerification phoneVerification =
-                phoneVerificationService.getByTokenOfThrow(cmd.phoneVerificationToken());
-        phoneVerification.assertPhoneMatches(cmd.phoneNumber());
+                phoneVerificationService.getByTokenOfThrow(signupCmd.phoneVerificationToken());
+        phoneVerification.assertPhoneMatches(signupCmd.phoneNumber());
         return phoneVerification;
     }
 
     /**
      * 새로운 회원 엔티티를 생성하고 저장합니다. UUID, 이메일, 이름, 전화번호로 회원 정보를 구성합니다.
      *
-     * @param cmd 회원가입 커맨드 객체
+     * @param signupCmd 회원가입 커맨드 객체
      * @return 저장된 Member 엔티티
      */
-    private Member createMember(SignupCommand cmd) {
+    private Member createMember(SignupCommand signupCmd) {
         Member member =
                 Member.builder()
                         .memberUuid(UuidUtil.newUuid())
-                        .email(cmd.email())
-                        .name(cmd.name())
-                        .phone(cmd.phoneNumber())
+                        .email(signupCmd.email())
+                        .name(signupCmd.name())
+                        .phone(signupCmd.phoneNumber())
                         .build();
         return memberRepository.save(member);
     }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
@@ -2,12 +2,12 @@ package com.fliqo.service;
 
 import java.util.List;
 
-import com.fliqo.config.JwtProperties;
-import com.fliqo.controller.dto.response.TokenResponseDto;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fliqo.config.JwtProperties;
+import com.fliqo.controller.dto.response.TokenResponseDto;
 import com.fliqo.domain.entity.Member;
 import com.fliqo.domain.entity.MemberCredential;
 import com.fliqo.domain.entity.PhoneVerification;
@@ -41,8 +41,7 @@ public class MemberService {
     }
 
     /**
-     * 회원가입을 처리합니다.
-     * 이메일 중복 검증, 전화번호 인증 확인, 회원 생성, 인증정보 저장 과정을 거칩니다.
+     * 회원가입을 처리합니다. 이메일 중복 검증, 전화번호 인증 확인, 회원 생성, 인증정보 저장 과정을 거칩니다.
      *
      * @param cmd 회원가입에 필요한 정보를 담은 커맨드 객체
      * @return 생성된 회원의 정보를 담은 SignupResult
@@ -61,8 +60,7 @@ public class MemberService {
     }
 
     /**
-     * 회원가입 요청의 유효성을 검증합니다.
-     * 이메일 중복 여부를 확인합니다.
+     * 회원가입 요청의 유효성을 검증합니다. 이메일 중복 여부를 확인합니다.
      *
      * @param cmd 회원가입 커맨드 객체
      * @throws IllegalStateException 이메일이 이미 사용 중인 경우
@@ -72,39 +70,38 @@ public class MemberService {
     }
 
     /**
-     * 전화번호 인증을 확인합니다.
-     * 인증 토큰을 조회하고 전화번호가 일치하는지 검증합니다.
+     * 전화번호 인증을 확인합니다. 인증 토큰을 조회하고 전화번호가 일치하는지 검증합니다.
      *
      * @param cmd 회원가입 커맨드 객체
      * @return 검증된 PhoneVerification 객체
      * @throws IllegalArgumentException 인증 토큰이 유효하지 않거나 전화번호가 일치하지 않는 경우
      */
     private PhoneVerification verifyPhone(SignupCommand cmd) {
-        PhoneVerification phoneVerification = phoneVerificationService.getByTokenOfThrow(cmd.phoneVerificationToken());
+        PhoneVerification phoneVerification =
+                phoneVerificationService.getByTokenOfThrow(cmd.phoneVerificationToken());
         phoneVerification.assertPhoneMatches(cmd.phoneNumber());
         return phoneVerification;
     }
 
     /**
-     * 새로운 회원 엔티티를 생성하고 저장합니다.
-     * UUID, 이메일, 이름, 전화번호로 회원 정보를 구성합니다.
+     * 새로운 회원 엔티티를 생성하고 저장합니다. UUID, 이메일, 이름, 전화번호로 회원 정보를 구성합니다.
      *
      * @param cmd 회원가입 커맨드 객체
      * @return 저장된 Member 엔티티
      */
     private Member createMember(SignupCommand cmd) {
-        Member member = Member.builder()
-                .memberUuid(UuidUtil.newUuid())
-                .email(cmd.email())
-                .name(cmd.name())
-                .phone(cmd.phoneNumber())
-                .build();
+        Member member =
+                Member.builder()
+                        .memberUuid(UuidUtil.newUuid())
+                        .email(cmd.email())
+                        .name(cmd.name())
+                        .phone(cmd.phoneNumber())
+                        .build();
         return memberRepository.save(member);
     }
 
     /**
-     * 회원의 인증정보(비밀번호)를 생성하고 저장합니다.
-     * 평문 비밀번호를 암호화하여 MemberCredential 엔티티로 저장합니다.
+     * 회원의 인증정보(비밀번호)를 생성하고 저장합니다. 평문 비밀번호를 암호화하여 MemberCredential 엔티티로 저장합니다.
      *
      * @param member 인증정보를 생성할 회원 엔티티
      * @param rawPassword 암호화되지 않은 평문 비밀번호
@@ -116,8 +113,7 @@ public class MemberService {
     }
 
     /**
-     * 회원가입 결과 응답 객체를 생성합니다.
-     * 저장된 회원 정보를 바탕으로 SignupResult DTO를 구성합니다.
+     * 회원가입 결과 응답 객체를 생성합니다. 저장된 회원 정보를 바탕으로 SignupResult DTO를 구성합니다.
      *
      * @param member 생성된 회원 엔티티
      * @return 회원 정보를 담은 SignupResult 응답 객체

--- a/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
@@ -2,6 +2,8 @@ package com.fliqo.service;
 
 import java.util.List;
 
+import com.fliqo.config.JwtProperties;
+import com.fliqo.controller.dto.response.TokenResponseDto;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +32,7 @@ public class MemberService {
     private final PhoneVerificationService phoneVerificationService;
     private final MemberPolicyValidator memberPolicyValidator;
     private final JwtService jwtService;
+    private final JwtProperties jwtProperties;
 
     @Transactional(readOnly = true)
     public EmailCheckResult checkEmail(EmailCheckCommand cmd) {
@@ -37,29 +40,89 @@ public class MemberService {
         return new EmailCheckResult(exists);
     }
 
+    /**
+     * 회원가입을 처리합니다.
+     * 이메일 중복 검증, 전화번호 인증 확인, 회원 생성, 인증정보 저장 과정을 거칩니다.
+     *
+     * @param cmd 회원가입에 필요한 정보를 담은 커맨드 객체
+     * @return 생성된 회원의 정보를 담은 SignupResult
+     * @throws IllegalStateException 이메일이 이미 사용 중인 경우
+     * @throws IllegalArgumentException 전화번호 인증이 유효하지 않은 경우
+     */
     @Transactional
     public SignupResult signup(SignupCommand cmd) {
+        validateSignupRequest(cmd);
+        PhoneVerification phoneVerification = verifyPhone(cmd);
+        Member member = createMember(cmd);
+        createCredential(member, cmd.rawPassword());
+        phoneVerificationService.consumeToken(phoneVerification);
+
+        return buildSignupResult(member);
+    }
+
+    /**
+     * 회원가입 요청의 유효성을 검증합니다.
+     * 이메일 중복 여부를 확인합니다.
+     *
+     * @param cmd 회원가입 커맨드 객체
+     * @throws IllegalStateException 이메일이 이미 사용 중인 경우
+     */
+    private void validateSignupRequest(SignupCommand cmd) {
         memberPolicyValidator.ensureEmailAvailable(cmd.email());
+    }
 
-        PhoneVerification pv =
-                phoneVerificationService.getByTokenOfThrow(cmd.phoneVerificationToken());
-        pv.assertPhoneMatches(cmd.phoneNumber());
+    /**
+     * 전화번호 인증을 확인합니다.
+     * 인증 토큰을 조회하고 전화번호가 일치하는지 검증합니다.
+     *
+     * @param cmd 회원가입 커맨드 객체
+     * @return 검증된 PhoneVerification 객체
+     * @throws IllegalArgumentException 인증 토큰이 유효하지 않거나 전화번호가 일치하지 않는 경우
+     */
+    private PhoneVerification verifyPhone(SignupCommand cmd) {
+        PhoneVerification phoneVerification = phoneVerificationService.getByTokenOfThrow(cmd.phoneVerificationToken());
+        phoneVerification.assertPhoneMatches(cmd.phoneNumber());
+        return phoneVerification;
+    }
 
-        Member member =
-                Member.builder()
-                        .memberUuid(UuidUtil.newUuid())
-                        .email(cmd.email())
-                        .name(cmd.name())
-                        .phone(cmd.phoneNumber())
-                        .build();
-        memberRepository.save(member);
+    /**
+     * 새로운 회원 엔티티를 생성하고 저장합니다.
+     * UUID, 이메일, 이름, 전화번호로 회원 정보를 구성합니다.
+     *
+     * @param cmd 회원가입 커맨드 객체
+     * @return 저장된 Member 엔티티
+     */
+    private Member createMember(SignupCommand cmd) {
+        Member member = Member.builder()
+                .memberUuid(UuidUtil.newUuid())
+                .email(cmd.email())
+                .name(cmd.name())
+                .phone(cmd.phoneNumber())
+                .build();
+        return memberRepository.save(member);
+    }
 
-        String hash = passwordEncoder.encode(cmd.rawPassword());
-        MemberCredential cred = MemberCredential.createNew(member, hash);
-        credentialRepository.save(cred);
+    /**
+     * 회원의 인증정보(비밀번호)를 생성하고 저장합니다.
+     * 평문 비밀번호를 암호화하여 MemberCredential 엔티티로 저장합니다.
+     *
+     * @param member 인증정보를 생성할 회원 엔티티
+     * @param rawPassword 암호화되지 않은 평문 비밀번호
+     */
+    private void createCredential(Member member, String rawPassword) {
+        String hash = passwordEncoder.encode(rawPassword);
+        MemberCredential credential = MemberCredential.createNew(member, hash);
+        credentialRepository.save(credential);
+    }
 
-        phoneVerificationService.consumeToken(pv);
-
+    /**
+     * 회원가입 결과 응답 객체를 생성합니다.
+     * 저장된 회원 정보를 바탕으로 SignupResult DTO를 구성합니다.
+     *
+     * @param member 생성된 회원 엔티티
+     * @return 회원 정보를 담은 SignupResult 응답 객체
+     */
+    private SignupResult buildSignupResult(Member member) {
         return SignupResult.builder()
                 .memberId(member.getId())
                 .memberUuid(member.getMemberUuid())
@@ -70,18 +133,29 @@ public class MemberService {
     }
 
     /**
-     * 이메일/비밀번호를 검증한 뒤, 사용자의 역할을 포함한 JWT를 발급합니다.
+     * 이메일/비밀번호를 검증한 뒤, JWT 토큰과 만료 시간을 포함한 응답을 생성합니다.
      *
      * @param email 로그인 이메일
      * @param rawPassword 평문 비밀번호
-     * @return 생성된 JWT 토큰 문자열
-     * @throws com.fliqo.exception.MemberException 자격 증명 검증 실패 시(내부적으로 {@link
-     *     com.fliqo.exception.MemberError} 사용)
+     * @return 액세스 토큰과 만료 시간을 담은 TokenResponseDto
+     * @throws com.fliqo.exception.MemberException 자격 증명 검증 실패 시
      */
     @Transactional
-    public String login(String email, String rawPassword) {
+    public TokenResponseDto login(String email, String rawPassword) {
         Member member = verifyCredential(email, rawPassword);
+        String accessToken = generateAccessToken(member);
+        long expirationSeconds = calculateExpirationSeconds();
 
+        return TokenResponseDto.of(accessToken, expirationSeconds);
+    }
+
+    /**
+     * 회원 정보를 기반으로 JWT 액세스 토큰을 생성합니다.
+     *
+     * @param member 인증된 회원 엔티티
+     * @return 생성된 JWT 토큰 문자열
+     */
+    public String generateAccessToken(Member member) {
         List<String> roles = List.of(member.getRole().name());
         return jwtService.createToken(member.getEmail(), roles);
     }
@@ -118,5 +192,14 @@ public class MemberService {
         }
 
         return member;
+    }
+
+    /**
+     * 액세스 토큰의 만료 시간을 초 단위로 계산합니다.
+     *
+     * @return 만료 시간(초)
+     */
+    private long calculateExpirationSeconds() {
+        return jwtProperties.getAccessMin() * 60;
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/PhoneVerificationService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/PhoneVerificationService.java
@@ -41,18 +41,22 @@ public class PhoneVerificationService {
      * @return 인증 세션 ID와 만료 정보를 담은 결과 객체
      */
     @Transactional
-    public PhoneVerificationStartResult start(PhoneVerificationStartCommand phoneVerificationStartCmd) {
+    public PhoneVerificationStartResult start(
+            PhoneVerificationStartCommand phoneVerificationStartCmd) {
         // 인증 코드 생성 및 엔터티 생성
         String code = generateCode();
-        PhoneVerification phoneVerification = PhoneVerification.createNew(phoneVerificationStartCmd.phoneNumber(), code);
+        PhoneVerification phoneVerification =
+                PhoneVerification.createNew(phoneVerificationStartCmd.phoneNumber(), code);
 
         // 저장
         repository.save(phoneVerification);
 
         // SMS 발송
-        smsSender.send(phoneVerificationStartCmd.phoneNumber(), "[Fliqo] 인증번호: " + code + " (유효시간 3분)");
+        smsSender.send(
+                phoneVerificationStartCmd.phoneNumber(), "[Fliqo] 인증번호: " + code + " (유효시간 3분)");
 
-        return PhoneVerificationStartResult.of(phoneVerification.getId(), phoneVerification.expiresInSeconds());
+        return PhoneVerificationStartResult.of(
+                phoneVerification.getId(), phoneVerification.expiresInSeconds());
     }
 
     /**
@@ -65,8 +69,10 @@ public class PhoneVerificationService {
      * @return 검증 토큰을 담은 결과 객체
      */
     @Transactional
-    public PhoneVerificationConfirmResult confirm(PhoneVerificationConfirmCommand phoneVerificationConfirmCmd) {
-        PhoneVerification phoneVerification = validator.mustExist(phoneVerificationConfirmCmd.verificationId());
+    public PhoneVerificationConfirmResult confirm(
+            PhoneVerificationConfirmCommand phoneVerificationConfirmCmd) {
+        PhoneVerification phoneVerification =
+                validator.mustExist(phoneVerificationConfirmCmd.verificationId());
         phoneVerification.verify(phoneVerificationConfirmCmd.code());
         repository.save(phoneVerification);
 

--- a/fliqo-member-api/src/main/java/com/fliqo/service/PhoneVerificationService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/PhoneVerificationService.java
@@ -37,22 +37,22 @@ public class PhoneVerificationService {
      *
      * <p>인증 세션을 생성하여 저장한 뒤, 대상 번호로 일회용 인증 코드를 SMS로 전송합니다.
      *
-     * @param cmd 휴대폰 번호를 담은 시작 명령
+     * @param phoneVerificationStartCmd 휴대폰 번호를 담은 시작 명령
      * @return 인증 세션 ID와 만료 정보를 담은 결과 객체
      */
     @Transactional
-    public PhoneVerificationStartResult start(PhoneVerificationStartCommand cmd) {
+    public PhoneVerificationStartResult start(PhoneVerificationStartCommand phoneVerificationStartCmd) {
         // 인증 코드 생성 및 엔터티 생성
         String code = generateCode();
-        PhoneVerification pv = PhoneVerification.createNew(cmd.phoneNumber(), code);
+        PhoneVerification phoneVerification = PhoneVerification.createNew(phoneVerificationStartCmd.phoneNumber(), code);
 
         // 저장
-        repository.save(pv);
+        repository.save(phoneVerification);
 
         // SMS 발송
-        smsSender.send(cmd.phoneNumber(), "[Fliqo] 인증번호: " + code + " (유효시간 3분)");
+        smsSender.send(phoneVerificationStartCmd.phoneNumber(), "[Fliqo] 인증번호: " + code + " (유효시간 3분)");
 
-        return PhoneVerificationStartResult.of(pv.getId(), pv.expiresInSeconds());
+        return PhoneVerificationStartResult.of(phoneVerification.getId(), phoneVerification.expiresInSeconds());
     }
 
     /**
@@ -61,16 +61,16 @@ public class PhoneVerificationService {
      * <p>세션 존재 여부 및 상태 검증은 {@link PhoneVerifyValidator}가 수행하며, 코드 일치/만료/시도 횟수 검증은 엔터티의 도메인
      * 로직({@link PhoneVerification#verify(String)})이 수행합니다.
      *
-     * @param cmd 인증 세션 ID와 사용자 입력 코드를 담은 확인 명령
+     * @param phoneVerificationConfirmCmd 인증 세션 ID와 사용자 입력 코드를 담은 확인 명령
      * @return 검증 토큰을 담은 결과 객체
      */
     @Transactional
-    public PhoneVerificationConfirmResult confirm(PhoneVerificationConfirmCommand cmd) {
-        PhoneVerification pv = validator.mustExist(cmd.verificationId());
-        pv.verify(cmd.code());
-        repository.save(pv);
+    public PhoneVerificationConfirmResult confirm(PhoneVerificationConfirmCommand phoneVerificationConfirmCmd) {
+        PhoneVerification phoneVerification = validator.mustExist(phoneVerificationConfirmCmd.verificationId());
+        phoneVerification.verify(phoneVerificationConfirmCmd.code());
+        repository.save(phoneVerification);
 
-        return PhoneVerificationConfirmResult.of(pv.getVerificationToken());
+        return PhoneVerificationConfirmResult.of(phoneVerification.getVerificationToken());
     }
 
     /**
@@ -89,11 +89,11 @@ public class PhoneVerificationService {
     /**
      * 검증 토큰을 소모 상태로 변경하여 재사용을 방지합니다.
      *
-     * @param pv 소모 처리할 인증 엔터티
+     * @param phoneVerification 소모 처리할 인증 엔터티
      */
     @Transactional
-    public void consumeToken(PhoneVerification pv) {
-        pv.consume();
-        repository.save(pv);
+    public void consumeToken(PhoneVerification phoneVerification) {
+        phoneVerification.consume();
+        repository.save(phoneVerification);
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/EmailCheckCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/EmailCheckCommand.java
@@ -1,7 +1,14 @@
 package com.fliqo.service.dto.request;
 
+import lombok.Builder;
+
+@Builder
 public record EmailCheckCommand(String email) {
     public EmailCheckCommand {
-        if (email != null) email = email.trim();
+        if (email != null) email = email.trim().toLowerCase();
+    }
+
+    public static EmailCheckCommand of(String email) {
+        return EmailCheckCommand.builder().email(email).build();
     }
 }

--- a/fliqo-member-api/src/main/resources/application.yml
+++ b/fliqo-member-api/src/main/resources/application.yml
@@ -3,6 +3,12 @@ server:
   forward-headers-strategy: framework
 
 spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
   jpa:
     hibernate:
       ddl-auto: update   # 테스트 편의용
@@ -25,3 +31,10 @@ springdoc:
     path: /swagger-ui.html
     try-it-out-enabled: true
   show-actuator: true
+
+jwt:
+  issuer: fliqo-service
+  access-min: 1440
+  refresh-day: 7
+  # 32바이트 이상을 Base64로
+  secret-base64: ${JWT_SECRET}


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 회원 서비스 레이어에 단일 책임 원칙(SRP)을 적용하여 코드 가독성과 유지보수성을 개선했습니다.
- 코드 전반에 걸쳐 사용된 축약 변수명과 매개변수명을 풀네임으로 변경하였습니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
1. MemberService.signup() 리팩토링
- 하나의 메소드를 6개의 세부 메소드로 분리
  - `validateSignupRequest()`: 이메일 중복 검증
  - `verifyPhone()`: 전화번호 인증 확인
  - `createMember()`: 회원 엔티티 생성 및 저장
  - `createCredential()`: 비밀번호 암호화 및 인증정보 저장
  - `buildSignupResult()`: 응답 DTO 생성
- `signup()` 메소드는 전체 흐름을 조율하는 역할만 수행

2. 로그인 로직 레이어 분리
- 컨트롤러의 토큰 만료시간 계산 로직을 서비스로 이동
- generateAccessToken() 메소드 추가로 토큰 생성 로직 분리
- calculateExpirationSeconds() 메소드로 만료시간 계산 분리

3. memberApi application.yml datasource, jwt yaml 매핑 추가

4. 문서화 광화
- 모든 public/private 메소드에 상세한 Javadoc 추가

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 회원가입 API 호출하여 정상적으로 회원이 생성되는지 확인
  - `POST /api/phone/verify/request`, `POST /api/phone/verify/confirm`, `POST /api/member/signup`
2. 로그인 API 호출하여 토큰이 정상적으로 발급되는지 확인
  - `POST /api/member/login`
  - 응답에 `accessToken`과 `expirationSeconds` 가 포함되어 있는지 확인


## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #29 
