### PR TITLE
fliqo-common api 응답 표준 포맷 및 예외 처리

### DIFF
--- a/fliqo-common/build.gradle
+++ b/fliqo-common/build.gradle
@@ -6,9 +6,13 @@ dependencies {
 
     // DTO에 Bean Validation 애노테이션
     api 'jakarta.validation:jakarta.validation-api'
+    api 'org.springframework:spring-web'
+    compileOnly 'jakarta.servlet:jakarta.servlet-api:6.0.0'
 
     // 유틸리티
     api 'org.apache.commons:commons-lang3'
+
+    api 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
 
 }
 

--- a/fliqo-common/src/main/java/com/fliqo/dto/CommonResponse.java
+++ b/fliqo-common/src/main/java/com/fliqo/dto/CommonResponse.java
@@ -1,0 +1,62 @@
+package com.fliqo.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fliqo.exception.ErrorCode;
+
+import java.time.LocalDateTime;
+
+/**
+ * 모든 API 응답의 표준 포맷
+ *
+ * @param <T> 응답 데이터 타입
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)  // null 필드는 JSON에서 제외
+public record CommonResponse<T>(
+        boolean success,        // 성공 여부 (true/false)
+        T data,                // 실제 데이터 (성공 시에만)
+        String message,        // 사용자 메시지 (선택)
+        String errorCode,      // 에러 코드 (실패 시에만)
+        LocalDateTime timestamp // 응답 생성 시간
+) {
+
+    /**
+     * 성공 응답 - 데이터만 반환
+     * 사용: 조회, 생성, 수정 등 데이터가 있는 경우
+     */
+    public static <T> CommonResponse<T> success(T data) {
+        return new CommonResponse<>(true, data, null, null, LocalDateTime.now());
+    }
+
+    /**
+     * 성공 응답 - 데이터 + 사용자 메시지
+     * 사용: 작업 완료 메시지를 사용자에게 보여줄 때
+     */
+    public static <T> CommonResponse<T> success(T data, String message) {
+        return new CommonResponse<>(true, data, message, null, LocalDateTime.now());
+    }
+
+    /**
+     * 성공 응답 - 메시지만 (데이터 없음)
+     * 사용: 삭제, 로그아웃 등 반환 데이터가 없는 경우
+     */
+    public static <T> CommonResponse<T> successWithMessage(String message) {
+        return new CommonResponse<>(true, null, message, null, LocalDateTime.now());
+    }
+
+    /**
+     * 실패 응답 - 커스텀 메시지 + 에러코드
+     * 사용: 동적 에러 메시지가 필요한 경우
+     */
+    public static <T> CommonResponse<T> error(String message, String errorCode) {
+        return new CommonResponse<>(false, null, message, errorCode, LocalDateTime.now());
+    }
+
+    /**
+     * 실패 응답 - ErrorCode enum 사용
+     * 사용: 표준화된 에러 코드/메시지를 사용하는 경우
+     */
+    public static <T> CommonResponse<T> error(ErrorCode errorCode) {
+        return new CommonResponse<>(false, null, errorCode.getMessage(),
+                errorCode.getCode(), LocalDateTime.now());
+    }
+}

--- a/fliqo-common/src/main/java/com/fliqo/dto/ErrorResponse.java
+++ b/fliqo-common/src/main/java/com/fliqo/dto/ErrorResponse.java
@@ -1,0 +1,89 @@
+package com.fliqo.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fliqo.exception.ErrorCode;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 에러 응답 전용 DTO.
+ * CommonResponse와 달리 Validation 에러처럼 필드별 상세 에러 정보가 필요한 경우 사용.
+ * 주로 Bean Validation (@Valid) 실패 시 여러 필드의 에러를 한 번에 전달할 때 사용.
+ *
+ * @see CommonResponse
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorResponse(
+        boolean success,
+        String message,
+        String errorCode,
+        LocalDateTime timestamp,
+        List<FieldError> errors
+) {
+
+    /**
+     * 컴팩트 생성자.
+     * success를 항상 false로 고정.
+     */
+    public ErrorResponse {
+        success = false;
+    }
+
+    /**
+     * 필드별 에러 정보를 담는 내부 Record.
+     * Bean Validation 실패 시 각 필드의 상세 에러 정보를 담음.
+     *
+     * @param field  에러가 발생한 필드명
+     * @param value  입력된 잘못된 값
+     * @param reason 에러 발생 이유
+     */
+    public record FieldError(
+            String field,
+            String value,
+            String reason
+    ) {}
+
+    /**
+     * 단순 에러 응답 생성 (필드별 상세 정보 없음).
+     * Validation 에러가 아닌 일반적인 비즈니스 에러에 사용.
+     *
+     * @param message   사용자에게 보여줄 에러 메시지
+     * @param errorCode 시스템 에러 코드
+     * @return ErrorResponse 인스턴스
+     */
+    public static ErrorResponse of(String message, String errorCode) {
+        return new ErrorResponse(false, message, errorCode, LocalDateTime.now(), null);
+    }
+
+    /**
+     * ErrorCode enum을 사용한 에러 응답 생성.
+     * 미리 정의된 표준 에러 코드를 사용할 때 편리.
+     *
+     * @param errorCode ErrorCode enum 값
+     * @return ErrorResponse 인스턴스
+     */
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(
+                false,
+                errorCode.getMessage(),
+                errorCode.getCode(),
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+    /**
+     * Validation 에러 응답 생성 (필드별 상세 정보 포함).
+     * Bean Validation (@Valid) 실패 시 사용.
+     * 여러 필드의 에러를 한 번에 전달하여 프론트엔드에서 각 입력 필드 아래에 에러 메시지를 표시 가능.
+     *
+     * @param message   전체 에러 메시지
+     * @param errorCode 에러 코드
+     * @param errors    필드별 에러 상세 정보 리스트
+     * @return ErrorResponse 인스턴스
+     */
+    public static ErrorResponse of(String message, String errorCode, List<FieldError> errors) {
+        return new ErrorResponse(false, message, errorCode, LocalDateTime.now(), errors);
+    }
+}

--- a/fliqo-common/src/main/java/com/fliqo/exception/BadRequestException.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/BadRequestException.java
@@ -1,0 +1,18 @@
+package com.fliqo.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 잘못된 요청 예외 (400 Bad Request).
+ * 클라이언트의 요청이 잘못되었거나 유효하지 않을 때 발생.
+ */
+public class BadRequestException extends BaseException {
+
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public BadRequestException(String message) {
+        super(HttpStatus.BAD_REQUEST, "BAD_REQUEST", message);
+    }
+}

--- a/fliqo-common/src/main/java/com/fliqo/exception/BaseException.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/BaseException.java
@@ -1,0 +1,57 @@
+package com.fliqo.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 모든 커스텀 예외의 최상위 추상 클래스.
+ * 시스템 내 모든 비즈니스 예외는 이 클래스를 상속받아야 함.
+ */
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
+
+    /**
+     * ErrorCode enum을 사용한 예외 생성.
+     *
+     * @param errorCode ErrorCode enum 값
+     */
+    protected BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.httpStatus = errorCode.getHttpStatus();
+        this.errorCode = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+
+    /**
+     * ErrorCode enum을 사용하되 메시지를 커스터마이징.
+     * 동적 메시지가 필요한 경우 사용.
+     *
+     * @param errorCode     ErrorCode enum 값
+     * @param customMessage 커스텀 메시지
+     */
+    protected BaseException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.httpStatus = errorCode.getHttpStatus();
+        this.errorCode = errorCode.getCode();
+        this.message = customMessage;
+    }
+
+    /**
+     * 직접 HTTP 상태 코드, 에러 코드, 메시지를 지정.
+     * ErrorCode에 없는 예외를 만들 때 사용.
+     *
+     * @param httpStatus HTTP 상태 코드
+     * @param errorCode  에러 코드
+     * @param message    에러 메시지
+     */
+    protected BaseException(HttpStatus httpStatus, String errorCode, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/fliqo-common/src/main/java/com/fliqo/exception/BusinessException.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/BusinessException.java
@@ -1,0 +1,22 @@
+package com.fliqo.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 비즈니스 로직 실행 중 발생하는 일반적인 예외.
+ * 특정 카테고리에 속하지 않는 비즈니스 예외에 사용.
+ */
+public class BusinessException extends BaseException {
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public BusinessException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, customMessage);
+    }
+
+    public BusinessException(HttpStatus httpStatus, String errorCode, String message) {
+        super(httpStatus, errorCode, message);
+    }
+}

--- a/fliqo-common/src/main/java/com/fliqo/exception/ErrorCode.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/ErrorCode.java
@@ -1,0 +1,37 @@
+package com.fliqo.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 시스템 전체에서 사용하는 표준 에러 코드.
+ * 필요에 따라 점진적으로 추가하여 사용.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // ===== Common (공통) =====
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_001", "서버 내부 오류가 발생했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COMMON_002", "입력값이 올바르지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON_003", "지원하지 않는 HTTP 메서드입니다."),
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "COMMON_004", "요청 값의 타입이 올바르지 않습니다."),
+    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "COMMON_005", "필수 파라미터가 누락되었습니다."),
+
+    // ===== Authentication (인증) =====
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_001", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_002", "접근 권한이 없습니다."),
+
+    // ===== Resource Not Found (리소스 없음) =====
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_001", "요청한 리소스를 찾을 수 없습니다."),
+
+    // 필요 시 아래와 같이 추가
+    // STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_001", "매장을 찾을 수 없습니다."),
+    // MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "회원을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/fliqo-common/src/main/java/com/fliqo/exception/NotFoundException.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/NotFoundException.java
@@ -1,0 +1,18 @@
+package com.fliqo.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 리소스를 찾을 수 없을 때 발생하는 예외 (404 Not Found).
+ * 회원, 매장, 예약 등의 엔티티 조회 실패 시 사용.
+ */
+public class NotFoundException extends BaseException {
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public NotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, "NOT_FOUND", message);
+    }
+}

--- a/fliqo-common/src/main/java/com/fliqo/exception/UnauthorizedException.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/UnauthorizedException.java
@@ -1,0 +1,23 @@
+package com.fliqo.exception;
+
+import com.fliqo.exception.BaseException;
+import com.fliqo.exception.ErrorCode;
+
+/**
+ * 인증 실패 예외 (401 Unauthorized).
+ * 로그인이 필요하거나 토큰이 유효하지 않을 때 발생.
+ */
+public class UnauthorizedException extends BaseException {
+
+    public UnauthorizedException() {
+        super(ErrorCode.UNAUTHORIZED);
+    }
+
+    public UnauthorizedException(String message) {
+        super(ErrorCode.UNAUTHORIZED, message);
+    }
+
+    public UnauthorizedException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/fliqo-common/src/main/java/com/fliqo/web/GlobalExceptionHandler.java
+++ b/fliqo-common/src/main/java/com/fliqo/web/GlobalExceptionHandler.java
@@ -1,0 +1,179 @@
+package com.fliqo.web;
+
+import com.fliqo.dto.CommonResponse;
+import com.fliqo.dto.ErrorResponse;
+import com.fliqo.exception.BaseException;
+import com.fliqo.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 전역 예외 처리 핸들러.
+ * 모든 Controller에서 발생하는 예외를 한 곳에서 처리하여 일관된 에러 응답 제공.
+ */
+@Slf4j
+@RestControllerAdvice
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnClass(jakarta.servlet.ServletException.class)
+public class GlobalExceptionHandler {
+
+    /**
+     * 커스텀 예외 처리 (BaseException 계열).
+     * 시스템에서 의도적으로 발생시킨 모든 비즈니스 예외를 처리.
+     *
+     * @param e BaseException 또는 하위 예외
+     * @return 에러 응답
+     */
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<CommonResponse<Void>> handleBaseException(BaseException e) {
+        log.error("BaseException: [{}] {}", e.getErrorCode(), e.getMessage(), e);
+
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(CommonResponse.error(e.getMessage(), e.getErrorCode()));
+    }
+
+    /**
+     * Bean Validation 예외 처리 (@Valid 실패).
+     * DTO 필드 검증 실패 시 각 필드별 에러 정보를 포함한 상세 응답 반환.
+     *
+     * @param e MethodArgumentNotValidException
+     * @return 필드별 에러 정보를 포함한 에러 응답
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(
+            MethodArgumentNotValidException e) {
+
+        List<ErrorResponse.FieldError> errors = e.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .map(error -> {
+                    FieldError fieldError = (FieldError) error;
+                    return new ErrorResponse.FieldError(
+                            fieldError.getField(),
+                            fieldError.getRejectedValue() != null
+                                    ? fieldError.getRejectedValue().toString() : "",
+                            fieldError.getDefaultMessage()
+                    );
+                })
+                .collect(Collectors.toList());
+
+        log.warn("Validation failed: {}", errors);
+
+        ErrorResponse response = ErrorResponse.of(
+                "입력값이 올바르지 않습니다.",
+                ErrorCode.INVALID_INPUT_VALUE.getCode(),
+                errors
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    /**
+     * 필수 파라미터 누락 예외 처리.
+     * @RequestParam(required=true) 파라미터가 없을 때 발생.
+     *
+     * @param e MissingServletRequestParameterException
+     * @return 에러 응답
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<CommonResponse<Void>> handleMissingParameter(
+            MissingServletRequestParameterException e) {
+
+        log.warn("Missing parameter: {}", e.getParameterName());
+
+        String message = String.format("필수 파라미터가 누락되었습니다: %s", e.getParameterName());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponse.error(message, ErrorCode.MISSING_REQUEST_PARAMETER.getCode()));
+    }
+
+    /**
+     * 타입 불일치 예외 처리.
+     * 파라미터 타입이 맞지 않을 때 발생 (예: String을 Integer로 변환 실패).
+     *
+     * @param e MethodArgumentTypeMismatchException
+     * @return 에러 응답
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<CommonResponse<Void>> handleTypeMismatch(
+            MethodArgumentTypeMismatchException e) {
+
+        log.warn("Type mismatch: {} - expected {}", e.getName(), e.getRequiredType());
+
+        String message = String.format("'%s' 파라미터의 타입이 올바르지 않습니다.", e.getName());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponse.error(message, ErrorCode.INVALID_TYPE_VALUE.getCode()));
+    }
+
+    /**
+     * HTTP 메서드 불일치 예외 처리.
+     * 지원하지 않는 HTTP 메서드로 요청했을 때 발생 (예: POST 엔드포인트에 GET 요청).
+     *
+     * @param e HttpRequestMethodNotSupportedException
+     * @return 에러 응답
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<CommonResponse<Void>> handleMethodNotSupported(
+            HttpRequestMethodNotSupportedException e) {
+
+        log.warn("Method not supported: {}", e.getMethod());
+
+        return ResponseEntity
+                .status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(CommonResponse.error(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    /**
+     * JSON 파싱 에러 처리.
+     * 요청 본문(Body)의 JSON 형식이 올바르지 않을 때 발생.
+     *
+     * @param e HttpMessageNotReadableException
+     * @return 에러 응답
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<CommonResponse<Void>> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException e) {
+
+        log.error("JSON parse error: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(CommonResponse.error("요청 본문을 읽을 수 없습니다.", "INVALID_JSON"));
+    }
+
+    /**
+     * 그 외 모든 예외 처리.
+     * 예상하지 못한 서버 오류 처리 (500 Internal Server Error).
+     *
+     * @param e Exception
+     * @return 에러 응답
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<Void>> handleException(Exception e) {
+        log.error("Unexpected error: {}", e.getMessage(), e);
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(CommonResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/CompetitorController.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/CompetitorController.java
@@ -20,6 +20,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import com.fliqo.dto.CommonResponse;
+
 @RestController
 @RequestMapping("/api/market/competitors")
 @Tag(name = "Competitors", description = "경쟁 분석")
@@ -44,14 +46,17 @@ public class CompetitorController {
     @ApiResponse(
             responseCode = "200",
             content =
-                    @Content(
-                            mediaType = MediaType.APPLICATION_JSON_VALUE,
-                            schema = @Schema(implementation = CompetitorBrandsResponse.class)))
+            @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = CommonResponse.class)))
     @GetMapping(value = "/brands", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<CompetitorBrandsResponse> getBrands(
+    public ResponseEntity<CommonResponse<CompetitorBrandsResponse>> getBrands(
 //            @RequestHeader(name = "Authorization", required = true) String authorization
     ) {
-        return ResponseEntity.ok(CompetitorBrandsResponse.sample());
+        CompetitorBrandsResponse data = CompetitorBrandsResponse.sample();
+        return ResponseEntity
+                .ok()
+                .body(CommonResponse.success(data, "브랜드 점유율 조회 성공"));
     }
 
     @Operation(summary = "가격 지수 조회")

--- a/fliqo-gateway/src/main/resources/application.yml
+++ b/fliqo-gateway/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     gateway:
       default-filters:
         - DedupeResponseHeader=Access-Control-Allow-Credentials Access-Control-Allow-Origin
+  profiles:
+    active: local
 logging:
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} - %msg%n"


### PR DESCRIPTION
## 📌 PR 개요

<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->

* `fliqo-common` 모듈에 **공통 API 응답 포맷 및 예외 처리 체계**를 추가했습니다.
* 모든 서비스(`member-api`, `core-api` 등)에서 일관된 형태로 응답을 반환하고,
  예외를 중앙에서 처리할 수 있도록 기반을 구축했습니다.

## 🔍 변경 사항

<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
* `CommonResponse<T>` : 성공/실패 응답 통합 포맷 추가 (`@JsonInclude` 적용)
* `ErrorCode` : 표준화된 에러 코드 및 기본 메시지 Enum 정의
* `BaseException` : 모든 커스텀 예외의 상위 클래스 추가
* `BusinessException`, `UnauthorizedException`, `NotFoundException`, `BadRequestException` : 세부 예외 클래스 추가
* `GlobalExceptionHandler` : 전역 예외 처리 핸들러 추가 (`@RestControllerAdvice`)

  * `@ConditionalOnWebApplication(SERVLET)` 적용 → WebFlux(gateway) 환경 제외
  * `BaseException`, `Validation`, `Unhandled` 예외별 응답 처리
* `build.gradle` : 공통 모듈 실행환경 분리를 위해 의존성 추가

  * `jackson-databind`: JSON 직렬화용
  * `jakarta.servlet-api`: 서블릿 예외 참조용(`compileOnly`)


## 🧪 테스트 방법

<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. fliqo-core-api 실행
- application-local.yml 기준으로 Core API 서버를 로컬에서 실행합니다.
- Gateway를 통하지 않고 직접 Core API (http://localhost:8082/swagger-ui.html) 접속합니다.

2. Swagger UI 접속
- 브라우저에서 http://localhost:8082/swagger-ui.html 접속
- 카테고리 중 브랜드 점유율 조회 API 선택 (GET /brands)

3. API 실행
- “Try it out” 클릭 → Execute 버튼을 눌러 실행
- 아래와 같은 JSON 응답이 내려오면 정상 작동입니다.
```json
{
  "success": true,
  "data": {
    "brands": [
      {
        "name": "스타벅스",
        "share": 0.33
      },
      {
        "name": "투썸플레이스",
        "share": 0.22
      },
      {
        "name": "이디야",
        "share": 0.15
      }
    ]
  },
  "message": "브랜드 점유율 조회 성공",
  "timestamp": "2025-10-10T21:51:34.212778"
}

```

## 📎 참고 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->

Ref: #27 
