### PR TITLE
비밀번호 재설정 api 추가

### DIFF
--- a/fliqo-common/src/main/java/com/fliqo/dto/CommonResponse.java
+++ b/fliqo-common/src/main/java/com/fliqo/dto/CommonResponse.java
@@ -1,62 +1,47 @@
 package com.fliqo.dto;
 
+import java.time.LocalDateTime;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fliqo.exception.ErrorCode;
-
-import java.time.LocalDateTime;
 
 /**
  * 모든 API 응답의 표준 포맷
  *
  * @param <T> 응답 데이터 타입
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)  // null 필드는 JSON에서 제외
+@JsonInclude(JsonInclude.Include.NON_NULL) // null 필드는 JSON에서 제외
 public record CommonResponse<T>(
-        boolean success,        // 성공 여부 (true/false)
-        T data,                // 실제 데이터 (성공 시에만)
-        String message,        // 사용자 메시지 (선택)
-        String errorCode,      // 에러 코드 (실패 시에만)
+        boolean success, // 성공 여부 (true/false)
+        T data, // 실제 데이터 (성공 시에만)
+        String message, // 사용자 메시지 (선택)
+        String errorCode, // 에러 코드 (실패 시에만)
         LocalDateTime timestamp // 응답 생성 시간
-) {
+        ) {
 
-    /**
-     * 성공 응답 - 데이터만 반환
-     * 사용: 조회, 생성, 수정 등 데이터가 있는 경우
-     */
+    /** 성공 응답 - 데이터만 반환 사용: 조회, 생성, 수정 등 데이터가 있는 경우 */
     public static <T> CommonResponse<T> success(T data) {
         return new CommonResponse<>(true, data, null, null, LocalDateTime.now());
     }
 
-    /**
-     * 성공 응답 - 데이터 + 사용자 메시지
-     * 사용: 작업 완료 메시지를 사용자에게 보여줄 때
-     */
+    /** 성공 응답 - 데이터 + 사용자 메시지 사용: 작업 완료 메시지를 사용자에게 보여줄 때 */
     public static <T> CommonResponse<T> success(T data, String message) {
         return new CommonResponse<>(true, data, message, null, LocalDateTime.now());
     }
 
-    /**
-     * 성공 응답 - 메시지만 (데이터 없음)
-     * 사용: 삭제, 로그아웃 등 반환 데이터가 없는 경우
-     */
+    /** 성공 응답 - 메시지만 (데이터 없음) 사용: 삭제, 로그아웃 등 반환 데이터가 없는 경우 */
     public static <T> CommonResponse<T> successWithMessage(String message) {
         return new CommonResponse<>(true, null, message, null, LocalDateTime.now());
     }
 
-    /**
-     * 실패 응답 - 커스텀 메시지 + 에러코드
-     * 사용: 동적 에러 메시지가 필요한 경우
-     */
+    /** 실패 응답 - 커스텀 메시지 + 에러코드 사용: 동적 에러 메시지가 필요한 경우 */
     public static <T> CommonResponse<T> error(String message, String errorCode) {
         return new CommonResponse<>(false, null, message, errorCode, LocalDateTime.now());
     }
 
-    /**
-     * 실패 응답 - ErrorCode enum 사용
-     * 사용: 표준화된 에러 코드/메시지를 사용하는 경우
-     */
+    /** 실패 응답 - ErrorCode enum 사용 사용: 표준화된 에러 코드/메시지를 사용하는 경우 */
     public static <T> CommonResponse<T> error(ErrorCode errorCode) {
-        return new CommonResponse<>(false, null, errorCode.getMessage(),
-                errorCode.getCode(), LocalDateTime.now());
+        return new CommonResponse<>(
+                false, null, errorCode.getMessage(), errorCode.getCode(), LocalDateTime.now());
     }
 }

--- a/fliqo-common/src/main/java/com/fliqo/dto/ErrorResponse.java
+++ b/fliqo-common/src/main/java/com/fliqo/dto/ErrorResponse.java
@@ -1,15 +1,14 @@
 package com.fliqo.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fliqo.exception.ErrorCode;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fliqo.exception.ErrorCode;
+
 /**
- * 에러 응답 전용 DTO.
- * CommonResponse와 달리 Validation 에러처럼 필드별 상세 에러 정보가 필요한 경우 사용.
- * 주로 Bean Validation (@Valid) 실패 시 여러 필드의 에러를 한 번에 전달할 때 사용.
+ * 에러 응답 전용 DTO. CommonResponse와 달리 Validation 에러처럼 필드별 상세 에러 정보가 필요한 경우 사용. 주로 Bean Validation
+ * (@Valid) 실패 시 여러 필드의 에러를 한 번에 전달할 때 사용.
  *
  * @see CommonResponse
  */
@@ -19,36 +18,26 @@ public record ErrorResponse(
         String message,
         String errorCode,
         LocalDateTime timestamp,
-        List<FieldError> errors
-) {
+        List<FieldError> errors) {
 
-    /**
-     * 컴팩트 생성자.
-     * success를 항상 false로 고정.
-     */
+    /** 컴팩트 생성자. success를 항상 false로 고정. */
     public ErrorResponse {
         success = false;
     }
 
     /**
-     * 필드별 에러 정보를 담는 내부 Record.
-     * Bean Validation 실패 시 각 필드의 상세 에러 정보를 담음.
+     * 필드별 에러 정보를 담는 내부 Record. Bean Validation 실패 시 각 필드의 상세 에러 정보를 담음.
      *
-     * @param field  에러가 발생한 필드명
-     * @param value  입력된 잘못된 값
+     * @param field 에러가 발생한 필드명
+     * @param value 입력된 잘못된 값
      * @param reason 에러 발생 이유
      */
-    public record FieldError(
-            String field,
-            String value,
-            String reason
-    ) {}
+    public record FieldError(String field, String value, String reason) {}
 
     /**
-     * 단순 에러 응답 생성 (필드별 상세 정보 없음).
-     * Validation 에러가 아닌 일반적인 비즈니스 에러에 사용.
+     * 단순 에러 응답 생성 (필드별 상세 정보 없음). Validation 에러가 아닌 일반적인 비즈니스 에러에 사용.
      *
-     * @param message   사용자에게 보여줄 에러 메시지
+     * @param message 사용자에게 보여줄 에러 메시지
      * @param errorCode 시스템 에러 코드
      * @return ErrorResponse 인스턴스
      */
@@ -57,30 +46,23 @@ public record ErrorResponse(
     }
 
     /**
-     * ErrorCode enum을 사용한 에러 응답 생성.
-     * 미리 정의된 표준 에러 코드를 사용할 때 편리.
+     * ErrorCode enum을 사용한 에러 응답 생성. 미리 정의된 표준 에러 코드를 사용할 때 편리.
      *
      * @param errorCode ErrorCode enum 값
      * @return ErrorResponse 인스턴스
      */
     public static ErrorResponse of(ErrorCode errorCode) {
         return new ErrorResponse(
-                false,
-                errorCode.getMessage(),
-                errorCode.getCode(),
-                LocalDateTime.now(),
-                null
-        );
+                false, errorCode.getMessage(), errorCode.getCode(), LocalDateTime.now(), null);
     }
 
     /**
-     * Validation 에러 응답 생성 (필드별 상세 정보 포함).
-     * Bean Validation (@Valid) 실패 시 사용.
-     * 여러 필드의 에러를 한 번에 전달하여 프론트엔드에서 각 입력 필드 아래에 에러 메시지를 표시 가능.
+     * Validation 에러 응답 생성 (필드별 상세 정보 포함). Bean Validation (@Valid) 실패 시 사용. 여러 필드의 에러를 한 번에 전달하여
+     * 프론트엔드에서 각 입력 필드 아래에 에러 메시지를 표시 가능.
      *
-     * @param message   전체 에러 메시지
+     * @param message 전체 에러 메시지
      * @param errorCode 에러 코드
-     * @param errors    필드별 에러 상세 정보 리스트
+     * @param errors 필드별 에러 상세 정보 리스트
      * @return ErrorResponse 인스턴스
      */
     public static ErrorResponse of(String message, String errorCode, List<FieldError> errors) {

--- a/fliqo-common/src/main/java/com/fliqo/exception/BadRequestException.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/BadRequestException.java
@@ -2,10 +2,7 @@ package com.fliqo.exception;
 
 import org.springframework.http.HttpStatus;
 
-/**
- * 잘못된 요청 예외 (400 Bad Request).
- * 클라이언트의 요청이 잘못되었거나 유효하지 않을 때 발생.
- */
+/** 잘못된 요청 예외 (400 Bad Request). 클라이언트의 요청이 잘못되었거나 유효하지 않을 때 발생. */
 public class BadRequestException extends BaseException {
 
     public BadRequestException(ErrorCode errorCode) {

--- a/fliqo-common/src/main/java/com/fliqo/exception/BaseException.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/BaseException.java
@@ -1,12 +1,10 @@
 package com.fliqo.exception;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-/**
- * 모든 커스텀 예외의 최상위 추상 클래스.
- * 시스템 내 모든 비즈니스 예외는 이 클래스를 상속받아야 함.
- */
+import lombok.Getter;
+
+/** 모든 커스텀 예외의 최상위 추상 클래스. 시스템 내 모든 비즈니스 예외는 이 클래스를 상속받아야 함. */
 @Getter
 public abstract class BaseException extends RuntimeException {
 
@@ -27,10 +25,9 @@ public abstract class BaseException extends RuntimeException {
     }
 
     /**
-     * ErrorCode enum을 사용하되 메시지를 커스터마이징.
-     * 동적 메시지가 필요한 경우 사용.
+     * ErrorCode enum을 사용하되 메시지를 커스터마이징. 동적 메시지가 필요한 경우 사용.
      *
-     * @param errorCode     ErrorCode enum 값
+     * @param errorCode ErrorCode enum 값
      * @param customMessage 커스텀 메시지
      */
     protected BaseException(ErrorCode errorCode, String customMessage) {
@@ -41,12 +38,11 @@ public abstract class BaseException extends RuntimeException {
     }
 
     /**
-     * 직접 HTTP 상태 코드, 에러 코드, 메시지를 지정.
-     * ErrorCode에 없는 예외를 만들 때 사용.
+     * 직접 HTTP 상태 코드, 에러 코드, 메시지를 지정. ErrorCode에 없는 예외를 만들 때 사용.
      *
      * @param httpStatus HTTP 상태 코드
-     * @param errorCode  에러 코드
-     * @param message    에러 메시지
+     * @param errorCode 에러 코드
+     * @param message 에러 메시지
      */
     protected BaseException(HttpStatus httpStatus, String errorCode, String message) {
         super(message);

--- a/fliqo-common/src/main/java/com/fliqo/exception/BusinessException.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/BusinessException.java
@@ -2,10 +2,7 @@ package com.fliqo.exception;
 
 import org.springframework.http.HttpStatus;
 
-/**
- * 비즈니스 로직 실행 중 발생하는 일반적인 예외.
- * 특정 카테고리에 속하지 않는 비즈니스 예외에 사용.
- */
+/** 비즈니스 로직 실행 중 발생하는 일반적인 예외. 특정 카테고리에 속하지 않는 비즈니스 예외에 사용. */
 public class BusinessException extends BaseException {
 
     public BusinessException(ErrorCode errorCode) {

--- a/fliqo-common/src/main/java/com/fliqo/exception/ErrorCode.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/ErrorCode.java
@@ -1,13 +1,11 @@
 package com.fliqo.exception;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-/**
- * 시스템 전체에서 사용하는 표준 에러 코드.
- * 필요에 따라 점진적으로 추가하여 사용.
- */
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 시스템 전체에서 사용하는 표준 에러 코드. 필요에 따라 점진적으로 추가하여 사용. */
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
@@ -26,10 +24,10 @@ public enum ErrorCode {
     // ===== Resource Not Found (리소스 없음) =====
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_001", "요청한 리소스를 찾을 수 없습니다."),
 
-    // 필요 시 아래와 같이 추가
-    // STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_001", "매장을 찾을 수 없습니다."),
-    // MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "회원을 찾을 수 없습니다."),
-    ;
+// 필요 시 아래와 같이 추가
+// STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_001", "매장을 찾을 수 없습니다."),
+// MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "회원을 찾을 수 없습니다."),
+;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/fliqo-common/src/main/java/com/fliqo/exception/NotFoundException.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/NotFoundException.java
@@ -2,10 +2,7 @@ package com.fliqo.exception;
 
 import org.springframework.http.HttpStatus;
 
-/**
- * 리소스를 찾을 수 없을 때 발생하는 예외 (404 Not Found).
- * 회원, 매장, 예약 등의 엔티티 조회 실패 시 사용.
- */
+/** 리소스를 찾을 수 없을 때 발생하는 예외 (404 Not Found). 회원, 매장, 예약 등의 엔티티 조회 실패 시 사용. */
 public class NotFoundException extends BaseException {
 
     public NotFoundException(ErrorCode errorCode) {

--- a/fliqo-common/src/main/java/com/fliqo/exception/UnauthorizedException.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/UnauthorizedException.java
@@ -1,12 +1,6 @@
 package com.fliqo.exception;
 
-import com.fliqo.exception.BaseException;
-import com.fliqo.exception.ErrorCode;
-
-/**
- * 인증 실패 예외 (401 Unauthorized).
- * 로그인이 필요하거나 토큰이 유효하지 않을 때 발생.
- */
+/** 인증 실패 예외 (401 Unauthorized). 로그인이 필요하거나 토큰이 유효하지 않을 때 발생. */
 public class UnauthorizedException extends BaseException {
 
     public UnauthorizedException() {

--- a/fliqo-common/src/main/java/com/fliqo/jwt/HeaderKeys.java
+++ b/fliqo-common/src/main/java/com/fliqo/jwt/HeaderKeys.java
@@ -2,6 +2,7 @@ package com.fliqo.jwt;
 
 public final class HeaderKeys {
     private HeaderKeys() {}
-    public static final String USER_ID  = "X-User-Id";
+
+    public static final String USER_ID = "X-User-Id";
     public static final String ROLES_CSV = "X-User-Roles";
 }

--- a/fliqo-common/src/main/java/com/fliqo/jwt/JwtClaimKeys.java
+++ b/fliqo-common/src/main/java/com/fliqo/jwt/JwtClaimKeys.java
@@ -2,6 +2,7 @@ package com.fliqo.jwt;
 
 public final class JwtClaimKeys {
     private JwtClaimKeys() {}
-    public static final String SUB   = "sub";
+
+    public static final String SUB = "sub";
     public static final String ROLES = "roles";
 }

--- a/fliqo-common/src/main/java/com/fliqo/jwt/JwtProperties.java
+++ b/fliqo-common/src/main/java/com/fliqo/jwt/JwtProperties.java
@@ -1,8 +1,9 @@
 package com.fliqo.jwt;
 
-import jakarta.validation.constraints.NotBlank;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotBlank;
 
 @Validated
 @ConfigurationProperties(prefix = "jwt")
@@ -10,11 +11,10 @@ public record JwtProperties(
         @NotBlank String issuer,
         @NotBlank String audience,
         @NotBlank String secret, // Base64 인코딩 키
-        HeaderInjection headerInjection
-) {
+        HeaderInjection headerInjection) {
     public record HeaderInjection(
             boolean enabled,
-            String userIdClaim,  // 기본 사용: "sub"
-            String rolesClaim    // 기본 사용: "roles"
-    ) {}
+            String userIdClaim, // 기본 사용: "sub"
+            String rolesClaim // 기본 사용: "roles"
+            ) {}
 }

--- a/fliqo-common/src/main/java/com/fliqo/web/GlobalExceptionHandler.java
+++ b/fliqo-common/src/main/java/com/fliqo/web/GlobalExceptionHandler.java
@@ -1,10 +1,8 @@
 package com.fliqo.web;
 
-import com.fliqo.dto.CommonResponse;
-import com.fliqo.dto.ErrorResponse;
-import com.fliqo.exception.BaseException;
-import com.fliqo.exception.ErrorCode;
-import lombok.extern.slf4j.Slf4j;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.http.HttpStatus;
@@ -18,13 +16,14 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import com.fliqo.dto.CommonResponse;
+import com.fliqo.dto.ErrorResponse;
+import com.fliqo.exception.BaseException;
+import com.fliqo.exception.ErrorCode;
 
-/**
- * 전역 예외 처리 핸들러.
- * 모든 Controller에서 발생하는 예외를 한 곳에서 처리하여 일관된 에러 응답 제공.
- */
+import lombok.extern.slf4j.Slf4j;
+
+/** 전역 예외 처리 핸들러. 모든 Controller에서 발생하는 예외를 한 곳에서 처리하여 일관된 에러 응답 제공. */
 @Slf4j
 @RestControllerAdvice
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
@@ -32,8 +31,7 @@ import java.util.stream.Collectors;
 public class GlobalExceptionHandler {
 
     /**
-     * 커스텀 예외 처리 (BaseException 계열).
-     * 시스템에서 의도적으로 발생시킨 모든 비즈니스 예외를 처리.
+     * 커스텀 예외 처리 (BaseException 계열). 시스템에서 의도적으로 발생시킨 모든 비즈니스 예외를 처리.
      *
      * @param e BaseException 또는 하위 예외
      * @return 에러 응답
@@ -42,14 +40,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleBaseException(BaseException e) {
         log.error("BaseException: [{}] {}", e.getErrorCode(), e.getMessage(), e);
 
-        return ResponseEntity
-                .status(e.getHttpStatus())
+        return ResponseEntity.status(e.getHttpStatus())
                 .body(CommonResponse.error(e.getMessage(), e.getErrorCode()));
     }
 
     /**
-     * Bean Validation 예외 처리 (@Valid 실패).
-     * DTO 필드 검증 실패 시 각 필드별 에러 정보를 포함한 상세 응답 반환.
+     * Bean Validation 예외 처리 (@Valid 실패). DTO 필드 검증 실패 시 각 필드별 에러 정보를 포함한 상세 응답 반환.
      *
      * @param e MethodArgumentNotValidException
      * @return 필드별 에러 정보를 포함한 에러 응답
@@ -58,36 +54,31 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleValidationException(
             MethodArgumentNotValidException e) {
 
-        List<ErrorResponse.FieldError> errors = e.getBindingResult()
-                .getAllErrors()
-                .stream()
-                .map(error -> {
-                    FieldError fieldError = (FieldError) error;
-                    return new ErrorResponse.FieldError(
-                            fieldError.getField(),
-                            fieldError.getRejectedValue() != null
-                                    ? fieldError.getRejectedValue().toString() : "",
-                            fieldError.getDefaultMessage()
-                    );
-                })
-                .collect(Collectors.toList());
+        List<ErrorResponse.FieldError> errors =
+                e.getBindingResult().getAllErrors().stream()
+                        .map(
+                                error -> {
+                                    FieldError fieldError = (FieldError) error;
+                                    return new ErrorResponse.FieldError(
+                                            fieldError.getField(),
+                                            fieldError.getRejectedValue() != null
+                                                    ? fieldError.getRejectedValue().toString()
+                                                    : "",
+                                            fieldError.getDefaultMessage());
+                                })
+                        .collect(Collectors.toList());
 
         log.warn("Validation failed: {}", errors);
 
-        ErrorResponse response = ErrorResponse.of(
-                "입력값이 올바르지 않습니다.",
-                ErrorCode.INVALID_INPUT_VALUE.getCode(),
-                errors
-        );
+        ErrorResponse response =
+                ErrorResponse.of(
+                        "입력값이 올바르지 않습니다.", ErrorCode.INVALID_INPUT_VALUE.getCode(), errors);
 
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(response);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
     /**
-     * 필수 파라미터 누락 예외 처리.
-     * @RequestParam(required=true) 파라미터가 없을 때 발생.
+     * 필수 파라미터 누락 예외 처리. @RequestParam(required=true) 파라미터가 없을 때 발생.
      *
      * @param e MissingServletRequestParameterException
      * @return 에러 응답
@@ -100,14 +91,12 @@ public class GlobalExceptionHandler {
 
         String message = String.format("필수 파라미터가 누락되었습니다: %s", e.getParameterName());
 
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(CommonResponse.error(message, ErrorCode.MISSING_REQUEST_PARAMETER.getCode()));
     }
 
     /**
-     * 타입 불일치 예외 처리.
-     * 파라미터 타입이 맞지 않을 때 발생 (예: String을 Integer로 변환 실패).
+     * 타입 불일치 예외 처리. 파라미터 타입이 맞지 않을 때 발생 (예: String을 Integer로 변환 실패).
      *
      * @param e MethodArgumentTypeMismatchException
      * @return 에러 응답
@@ -120,14 +109,12 @@ public class GlobalExceptionHandler {
 
         String message = String.format("'%s' 파라미터의 타입이 올바르지 않습니다.", e.getName());
 
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(CommonResponse.error(message, ErrorCode.INVALID_TYPE_VALUE.getCode()));
     }
 
     /**
-     * HTTP 메서드 불일치 예외 처리.
-     * 지원하지 않는 HTTP 메서드로 요청했을 때 발생 (예: POST 엔드포인트에 GET 요청).
+     * HTTP 메서드 불일치 예외 처리. 지원하지 않는 HTTP 메서드로 요청했을 때 발생 (예: POST 엔드포인트에 GET 요청).
      *
      * @param e HttpRequestMethodNotSupportedException
      * @return 에러 응답
@@ -138,14 +125,12 @@ public class GlobalExceptionHandler {
 
         log.warn("Method not supported: {}", e.getMethod());
 
-        return ResponseEntity
-                .status(HttpStatus.METHOD_NOT_ALLOWED)
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
                 .body(CommonResponse.error(ErrorCode.METHOD_NOT_ALLOWED));
     }
 
     /**
-     * JSON 파싱 에러 처리.
-     * 요청 본문(Body)의 JSON 형식이 올바르지 않을 때 발생.
+     * JSON 파싱 에러 처리. 요청 본문(Body)의 JSON 형식이 올바르지 않을 때 발생.
      *
      * @param e HttpMessageNotReadableException
      * @return 에러 응답
@@ -156,14 +141,12 @@ public class GlobalExceptionHandler {
 
         log.error("JSON parse error: {}", e.getMessage());
 
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(CommonResponse.error("요청 본문을 읽을 수 없습니다.", "INVALID_JSON"));
     }
 
     /**
-     * 그 외 모든 예외 처리.
-     * 예상하지 못한 서버 오류 처리 (500 Internal Server Error).
+     * 그 외 모든 예외 처리. 예상하지 못한 서버 오류 처리 (500 Internal Server Error).
      *
      * @param e Exception
      * @return 에러 응답
@@ -172,8 +155,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleException(Exception e) {
         log.error("Unexpected error: {}", e.getMessage(), e);
 
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(CommonResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/fliqo-core-api/src/main/java/com/fliqo/controller/CompetitorController.java
+++ b/fliqo-core-api/src/main/java/com/fliqo/controller/CompetitorController.java
@@ -13,14 +13,13 @@ import com.fliqo.controller.dto.response.competitor.CompetitorListResponse;
 import com.fliqo.controller.dto.response.competitor.CompetitorMapResponse;
 import com.fliqo.controller.dto.response.competitor.CompetitorPriceIndexResponse;
 import com.fliqo.controller.dto.response.competitor.CompetitorSummaryResponse;
+import com.fliqo.dto.CommonResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
-import com.fliqo.dto.CommonResponse;
 
 @RestController
 @RequestMapping("/api/market/competitors")
@@ -46,17 +45,16 @@ public class CompetitorController {
     @ApiResponse(
             responseCode = "200",
             content =
-            @Content(
-                    mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = CommonResponse.class)))
+                    @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = CommonResponse.class)))
     @GetMapping(value = "/brands", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<CommonResponse<CompetitorBrandsResponse>> getBrands(
-//            @RequestHeader(name = "Authorization", required = true) String authorization
-    ) {
+            //            @RequestHeader(name = "Authorization", required = true) String
+            // authorization
+            ) {
         CompetitorBrandsResponse data = CompetitorBrandsResponse.sample();
-        return ResponseEntity
-                .ok()
-                .body(CommonResponse.success(data, "브랜드 점유율 조회 성공"));
+        return ResponseEntity.ok().body(CommonResponse.success(data, "브랜드 점유율 조회 성공"));
     }
 
     @Operation(summary = "가격 지수 조회")

--- a/fliqo-gateway/src/main/java/com/fliqo/GatewayApplication.java
+++ b/fliqo-gateway/src/main/java/com/fliqo/GatewayApplication.java
@@ -1,10 +1,11 @@
 package com.fliqo;
 
-import com.fliqo.jwt.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import com.fliqo.jwt.JwtProperties;
 
 @ConfigurationPropertiesScan(basePackageClasses = JwtProperties.class)
 @EnableConfigurationProperties(JwtProperties.class)

--- a/fliqo-gateway/src/main/java/com/fliqo/config/GatewayAuthenticatedHeaderFilter.java
+++ b/fliqo-gateway/src/main/java/com/fliqo/config/GatewayAuthenticatedHeaderFilter.java
@@ -1,21 +1,24 @@
 package com.fliqo.config;
 
-import com.fliqo.jwt.HeaderKeys;
-import com.fliqo.jwt.JwtProperties;
+import static com.fliqo.jwt.JwtClaimKeys.SUB;
+
+import java.util.stream.Collectors;
+
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
-import reactor.core.publisher.Mono;
-import static com.fliqo.jwt.JwtClaimKeys.SUB;
 
-import java.util.stream.Collectors;
+import com.fliqo.jwt.HeaderKeys;
+import com.fliqo.jwt.JwtProperties;
+
+import reactor.core.publisher.Mono;
 
 @Component
 public class GatewayAuthenticatedHeaderFilter implements GlobalFilter, Ordered {
@@ -40,44 +43,50 @@ public class GatewayAuthenticatedHeaderFilter implements GlobalFilter, Ordered {
         return ReactiveSecurityContextHolder.getContext()
                 .map(SecurityContext::getAuthentication)
                 .filter(auth -> auth != null && auth.isAuthenticated())
-                .flatMap(auth -> {
-                    if (auth == null || !auth.isAuthenticated()) {
-                        return chain.filter(exchange);
-                    }
+                .flatMap(
+                        auth -> {
+                            if (auth == null || !auth.isAuthenticated()) {
+                                return chain.filter(exchange);
+                            }
 
-                    String userIdClaim = props.headerInjection().userIdClaim() != null
-                            ? props.headerInjection().userIdClaim()
-                            : SUB;
+                            String userIdClaim =
+                                    props.headerInjection().userIdClaim() != null
+                                            ? props.headerInjection().userIdClaim()
+                                            : SUB;
 
-                    final String userId;
-                    if (auth instanceof JwtAuthenticationToken jwtAuth) {
-                        Object claimValue = jwtAuth.getToken().getClaim(userIdClaim);
-                        if (claimValue != null) {
-                            userId = String.valueOf(claimValue);
-                        } else {
-                            userId = jwtAuth.getName();
-                        }
-                    } else {
-                        userId = auth.getName();
-                    }
-
-                    final String rolesCsv = auth.getAuthorities().stream()
-                            .map(GrantedAuthority::getAuthority)
-                            .collect(Collectors.joining(","));
-
-                    ServerHttpRequest mutated = exchange.getRequest().mutate()
-                            .headers(h -> {
-                                if (userId != null && !userId.isBlank()) {
-                                    h.set(HeaderKeys.USER_ID, userId);
+                            final String userId;
+                            if (auth instanceof JwtAuthenticationToken jwtAuth) {
+                                Object claimValue = jwtAuth.getToken().getClaim(userIdClaim);
+                                if (claimValue != null) {
+                                    userId = String.valueOf(claimValue);
+                                } else {
+                                    userId = jwtAuth.getName();
                                 }
-                                if (!rolesCsv.isBlank()) {
-                                    h.set(HeaderKeys.ROLES_CSV, rolesCsv);
-                                }
-                            })
-                            .build();
+                            } else {
+                                userId = auth.getName();
+                            }
 
-                    return chain.filter(exchange.mutate().request(mutated).build());
-                })
+                            final String rolesCsv =
+                                    auth.getAuthorities().stream()
+                                            .map(GrantedAuthority::getAuthority)
+                                            .collect(Collectors.joining(","));
+
+                            ServerHttpRequest mutated =
+                                    exchange.getRequest()
+                                            .mutate()
+                                            .headers(
+                                                    h -> {
+                                                        if (userId != null && !userId.isBlank()) {
+                                                            h.set(HeaderKeys.USER_ID, userId);
+                                                        }
+                                                        if (!rolesCsv.isBlank()) {
+                                                            h.set(HeaderKeys.ROLES_CSV, rolesCsv);
+                                                        }
+                                                    })
+                                            .build();
+
+                            return chain.filter(exchange.mutate().request(mutated).build());
+                        })
                 .switchIfEmpty(chain.filter(exchange));
     }
 

--- a/fliqo-gateway/src/main/java/com/fliqo/config/SecurityConfig.java
+++ b/fliqo-gateway/src/main/java/com/fliqo/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.fliqo.config;
 
-import com.fliqo.jwt.JwtAuthorityConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -8,11 +7,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint;
 import org.springframework.security.web.server.authorization.HttpStatusServerAccessDeniedHandler;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
-import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
+
+import com.fliqo.jwt.JwtAuthorityConverter;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -22,41 +23,53 @@ public class SecurityConfig {
     public SecurityWebFilterChain securityWebFilterChain(
             ServerHttpSecurity http,
             ReactiveJwtDecoder jwtDecoder,
-            JwtAuthorityConverter authorityConverter
-    ) {
-        http.authorizeExchange(reg -> reg
-                .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                .pathMatchers("/actuator/**").permitAll()
-                .pathMatchers("/api/auth/**").permitAll()
-                .pathMatchers(HttpMethod.POST,
-                        "/api/member/login",
-                        "/api/member/signup",
-                        "/api/member/email-check",
-                        "/api/member/phone/**"
-                ).permitAll()
-                .pathMatchers("/swagger-ui.html", "/swagger-ui/**").permitAll()
-                .pathMatchers("/v3/api-docs/**").permitAll()
-                .anyExchange().authenticated()
-        );
+            JwtAuthorityConverter authorityConverter) {
+        http.authorizeExchange(
+                reg ->
+                        reg.pathMatchers(HttpMethod.OPTIONS, "/**")
+                                .permitAll()
+                                .pathMatchers("/actuator/**")
+                                .permitAll()
+                                .pathMatchers("/api/auth/**")
+                                .permitAll()
+                                .pathMatchers(
+                                        HttpMethod.POST,
+                                        "/api/member/login",
+                                        "/api/member/signup",
+                                        "/api/member/email-check",
+                                        "/api/member/phone/**")
+                                .permitAll()
+                                .pathMatchers("/swagger-ui.html", "/swagger-ui/**")
+                                .permitAll()
+                                .pathMatchers("/v3/api-docs/**")
+                                .permitAll()
+                                .anyExchange()
+                                .authenticated());
 
         http.csrf(ServerHttpSecurity.CsrfSpec::disable);
 
-        http.exceptionHandling(e -> e
-                .authenticationEntryPoint(new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED))
-                .accessDeniedHandler(new HttpStatusServerAccessDeniedHandler(HttpStatus.FORBIDDEN))
-        );
+        http.exceptionHandling(
+                e ->
+                        e.authenticationEntryPoint(
+                                        new HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED))
+                                .accessDeniedHandler(
+                                        new HttpStatusServerAccessDeniedHandler(
+                                                HttpStatus.FORBIDDEN)));
 
+        http.oauth2ResourceServer(
+                oauth2 ->
+                        oauth2.jwt(
+                                jwtSpec -> {
+                                    jwtSpec.jwtDecoder(jwtDecoder);
+                                    JwtAuthenticationConverter delegate =
+                                            new JwtAuthenticationConverter();
+                                    delegate.setJwtGrantedAuthoritiesConverter(
+                                            jwt -> authorityConverter.convert(jwt));
 
-        http.oauth2ResourceServer(oauth2 -> oauth2
-                .jwt(jwtSpec -> {
-                    jwtSpec.jwtDecoder(jwtDecoder);
-                    JwtAuthenticationConverter delegate = new JwtAuthenticationConverter();
-                    delegate.setJwtGrantedAuthoritiesConverter(jwt -> authorityConverter.convert(jwt));
-
-                    jwtSpec.jwtAuthenticationConverter(new ReactiveJwtAuthenticationConverterAdapter(delegate));
-
-                })
-        );
+                                    jwtSpec.jwtAuthenticationConverter(
+                                            new ReactiveJwtAuthenticationConverterAdapter(
+                                                    delegate));
+                                }));
 
         return http.build();
     }

--- a/fliqo-gateway/src/main/java/com/fliqo/config/SecurityConfig.java
+++ b/fliqo-gateway/src/main/java/com/fliqo/config/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
                                         "/api/member/login",
                                         "/api/member/signup",
                                         "/api/member/email-check",
-                                        "/api/member/phone/**")
+                                        "/api/member/phone/**",
+                                        "/api/member/password/reset/**")
                                 .permitAll()
                                 .pathMatchers("/swagger-ui.html", "/swagger-ui/**")
                                 .permitAll()

--- a/fliqo-gateway/src/main/java/com/fliqo/jwt/JwtAuthorityConverter.java
+++ b/fliqo-gateway/src/main/java/com/fliqo/jwt/JwtAuthorityConverter.java
@@ -1,13 +1,13 @@
 package com.fliqo.jwt;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Component
 public class JwtAuthorityConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
@@ -21,10 +21,11 @@ public class JwtAuthorityConverter implements Converter<Jwt, Collection<GrantedA
     @Override
     public Collection<GrantedAuthority> convert(Jwt jwt) {
 
-        String rolesClaim = Optional.ofNullable(props.headerInjection())
-                .map(JwtProperties.HeaderInjection::rolesClaim)
-                .filter(s -> !s.isBlank())
-                .orElse(JwtClaimKeys.ROLES);
+        String rolesClaim =
+                Optional.ofNullable(props.headerInjection())
+                        .map(JwtProperties.HeaderInjection::rolesClaim)
+                        .filter(s -> !s.isBlank())
+                        .orElse(JwtClaimKeys.ROLES);
 
         Object rolesObj = jwt.getClaim(rolesClaim);
 
@@ -43,9 +44,7 @@ public class JwtAuthorityConverter implements Converter<Jwt, Collection<GrantedA
         if (rolesObj instanceof Collection<?> col) {
             tokens = col.stream().map(String::valueOf).toList();
         } else if (rolesObj instanceof String s) {
-            tokens = Arrays.stream(s.split("[,\\s]+"))
-                    .filter(t -> !t.isBlank())
-                    .toList();
+            tokens = Arrays.stream(s.split("[,\\s]+")).filter(t -> !t.isBlank()).toList();
         } else {
             tokens = List.of();
         }

--- a/fliqo-gateway/src/main/java/com/fliqo/jwt/JwtDecoderConfig.java
+++ b/fliqo-gateway/src/main/java/com/fliqo/jwt/JwtDecoderConfig.java
@@ -1,7 +1,9 @@
 package com.fliqo.jwt;
 
-import io.jsonwebtoken.io.Decoders;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import java.util.Objects;
+
+import javax.crypto.spec.SecretKeySpec;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
@@ -11,9 +13,7 @@ import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.*;
 
-
-import javax.crypto.spec.SecretKeySpec;
-import java.util.Objects;
+import io.jsonwebtoken.io.Decoders;
 
 @Configuration
 public class JwtDecoderConfig {
@@ -28,10 +28,10 @@ public class JwtDecoderConfig {
         byte[] keyBytes = Decoders.BASE64.decode(props.secret());
         var secretKey = new SecretKeySpec(keyBytes, "HmacSHA256");
 
-        NimbusReactiveJwtDecoder decoder = NimbusReactiveJwtDecoder
-                .withSecretKey(secretKey)
-                .macAlgorithm(MacAlgorithm.HS256)
-                .build();
+        NimbusReactiveJwtDecoder decoder =
+                NimbusReactiveJwtDecoder.withSecretKey(secretKey)
+                        .macAlgorithm(MacAlgorithm.HS256)
+                        .build();
 
         OAuth2TokenValidator<Jwt> withIssuer =
                 JwtValidators.createDefaultWithIssuer(props.issuer());
@@ -42,23 +42,23 @@ public class JwtDecoderConfig {
         return decoder;
     }
 
-    private OAuth2TokenValidator<Jwt> getJwtOAuth2TokenValidator(OAuth2TokenValidator<Jwt> withIssuer) {
-        OAuth2TokenValidator<Jwt> withAudience = token -> {
-            var audiences = token.getAudience();
-            if (audiences == null || audiences.stream().noneMatch(a -> Objects.equals(a, props.audience()))) {
-                return OAuth2TokenValidatorResult.failure(
-                        new OAuth2Error(
-                                "invalid_token",
-                                "필수 audience 값이 누락되었습니다: " + props.audience(),
-                                null
-                        )
-                );
-            }
-            return OAuth2TokenValidatorResult.success();
-        };
+    private OAuth2TokenValidator<Jwt> getJwtOAuth2TokenValidator(
+            OAuth2TokenValidator<Jwt> withIssuer) {
+        OAuth2TokenValidator<Jwt> withAudience =
+                token -> {
+                    var audiences = token.getAudience();
+                    if (audiences == null
+                            || audiences.stream()
+                                    .noneMatch(a -> Objects.equals(a, props.audience()))) {
+                        return OAuth2TokenValidatorResult.failure(
+                                new OAuth2Error(
+                                        "invalid_token",
+                                        "필수 audience 값이 누락되었습니다: " + props.audience(),
+                                        null));
+                    }
+                    return OAuth2TokenValidatorResult.success();
+                };
 
-        return new DelegatingOAuth2TokenValidator<>(
-                withIssuer, withAudience
-        );
+        return new DelegatingOAuth2TokenValidator<>(withIssuer, withAudience);
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/MemberApiApplication.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/MemberApiApplication.java
@@ -1,11 +1,12 @@
 package com.fliqo;
 
-import com.fliqo.config.AuthProperties;
-import com.fliqo.jwt.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
+import com.fliqo.config.AuthProperties;
+import com.fliqo.jwt.JwtProperties;
 
 @ConfigurationPropertiesScan(basePackageClasses = JwtProperties.class)
 @EnableConfigurationProperties(AuthProperties.class)

--- a/fliqo-member-api/src/main/java/com/fliqo/config/AuthProperties.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/config/AuthProperties.java
@@ -5,7 +5,4 @@ import org.springframework.validation.annotation.Validated;
 
 @Validated
 @ConfigurationProperties(prefix = "auth")
-public record AuthProperties(
-        long accessMin,
-        long refreshDay
-) {}
+public record AuthProperties(long accessMin, long refreshDay) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/config/OpenApiConfig.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/config/OpenApiConfig.java
@@ -1,14 +1,15 @@
 package com.fliqo.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
 public class OpenApiConfig {
@@ -20,15 +21,20 @@ public class OpenApiConfig {
 
         return new OpenAPI()
                 // 게이트웨이를 경유해 호출되도록 서버 URL을 gateway로 지정 (로컬 기준)
-                .servers(List.of(new Server().url("http://localhost:8080").description("via gateway")))
+                .servers(
+                        List.of(
+                                new Server()
+                                        .url("http://localhost:8080")
+                                        .description("via gateway")))
                 // Bearer JWT 스키마 등록
-                .components(new Components().addSecuritySchemes(
-                        SCHEME,
-                        new SecurityScheme()
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")
-                ))
+                .components(
+                        new Components()
+                                .addSecuritySchemes(
+                                        SCHEME,
+                                        new SecurityScheme()
+                                                .type(SecurityScheme.Type.HTTP)
+                                                .scheme("bearer")
+                                                .bearerFormat("JWT")))
                 // 전역으로 보안 요구 추가(각 API에 자동 적용)
                 .addSecurityItem(new SecurityRequirement().addList(SCHEME));
     }

--- a/fliqo-member-api/src/main/java/com/fliqo/config/SecurityConfig.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/config/SecurityConfig.java
@@ -25,7 +25,8 @@ public class SecurityConfig {
                                                 "/api/member/email-check",
                                                 "/api/member/phone/**",
                                                 "/api/member/signup",
-                                                "/api/member/login")
+                                                "/api/member/login",
+                                                "/api/member/password/reset/**")
                                         .permitAll()
                                         .requestMatchers(HttpMethod.GET, "/api/member/me")
                                         .permitAll()

--- a/fliqo-member-api/src/main/java/com/fliqo/config/SecurityConfig.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
                                                 "/api/member/signup",
                                                 "/api/member/login")
                                         .permitAll()
-                                        .requestMatchers(HttpMethod.GET, "/api/member/me").permitAll()
+                                        .requestMatchers(HttpMethod.GET, "/api/member/me")
+                                        .permitAll()
                                         .requestMatchers("/error")
                                         .permitAll()
                                         .anyRequest()

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -1,8 +1,11 @@
 package com.fliqo.controller;
 
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.fliqo.controller.dto.request.*;
 import com.fliqo.controller.dto.response.*;
@@ -20,9 +23,6 @@ import com.fliqo.service.validator.MemberPolicyValidator;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.server.ResponseStatusException;
-
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -107,14 +107,12 @@ public class MemberController {
     @GetMapping("/me")
     public Map<String, Object> me(
             @RequestHeader(value = "X-User-Id", required = false) String userId,
-            @RequestHeader(value = "X-User-Roles", required = false) String rolesCsv
-    ) {
+            @RequestHeader(value = "X-User-Roles", required = false) String rolesCsv) {
         if (userId == null || userId.isBlank()) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Missing X-User-Id");
         }
         return Map.of(
                 "userId", userId,
-                "roles", rolesCsv
-        );
+                "roles", rolesCsv);
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -2,6 +2,9 @@ package com.fliqo.controller;
 
 import java.util.Map;
 
+import com.fliqo.service.PasswordResetService;
+import com.fliqo.service.dto.request.*;
+import com.fliqo.service.dto.response.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,14 +14,6 @@ import com.fliqo.controller.dto.request.*;
 import com.fliqo.controller.dto.response.*;
 import com.fliqo.service.MemberService;
 import com.fliqo.service.PhoneVerificationService;
-import com.fliqo.service.dto.request.EmailCheckCommand;
-import com.fliqo.service.dto.request.PhoneVerificationConfirmCommand;
-import com.fliqo.service.dto.request.PhoneVerificationStartCommand;
-import com.fliqo.service.dto.request.SignupCommand;
-import com.fliqo.service.dto.response.EmailCheckResult;
-import com.fliqo.service.dto.response.PhoneVerificationConfirmResult;
-import com.fliqo.service.dto.response.PhoneVerificationStartResult;
-import com.fliqo.service.dto.response.SignupResult;
 import com.fliqo.service.validator.MemberPolicyValidator;
 
 import jakarta.validation.Valid;
@@ -31,6 +26,7 @@ public class MemberController {
     private final MemberService memberService;
     private final PhoneVerificationService phoneVerificationService;
     private final MemberPolicyValidator memberPolicyValidator;
+    private final PasswordResetService passwordResetService;
 
     @PostMapping("/email-check")
     public ResponseEntity<ApiResponse<EmailCheckResponse>> check(
@@ -114,5 +110,31 @@ public class MemberController {
         return Map.of(
                 "userId", userId,
                 "roles", rolesCsv);
+    }
+
+    @PostMapping("/password/reset/request")
+    public ResponseEntity<ApiResponse<PasswordResetStartResult>> requestPasswordReset(
+            @Valid @RequestBody PasswordResetRequest passwordResetRequest
+    ) {
+        PasswordResetStartResult passwordResetStartResult =
+                passwordResetService.start(PasswordResetStartCommand.of(passwordResetRequest.email(), passwordResetRequest.phoneNumber()));
+        return ResponseEntity.ok(ApiResponse.ok(passwordResetStartResult));
+    }
+
+    @PostMapping("/password/reset/verify")
+    public ResponseEntity<ApiResponse<PasswordResetVerifyResult>> verifyPhoneCode(
+            @Valid @RequestBody PasswordResetVerifyRequest passwordResetVerifyRequest
+    ) {
+        PasswordResetVerifyResult passwordResetVerifyResult =
+                passwordResetService.verify(PasswordResetVerifyCommand.of(passwordResetVerifyRequest.verificationId(), passwordResetVerifyRequest.code()));
+        return ResponseEntity.ok(ApiResponse.ok(passwordResetVerifyResult));
+    }
+
+    @PostMapping("/password/reset/confirm")
+    public ResponseEntity<ApiResponse<String>> confirmPasswordReset(
+            @Valid @RequestBody PasswordResetConfirmRequest passwordResetConfirmRequest
+    ) {
+        passwordResetService.confirm(PasswordResetConfirmCommand.of(passwordResetConfirmRequest.resetToken(), passwordResetConfirmRequest.newPassword()));
+        return ResponseEntity.ok(ApiResponse.ok("새로운 비밀번호로 변경되었습니다."));
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -2,9 +2,6 @@ package com.fliqo.controller;
 
 import java.util.Map;
 
-import com.fliqo.service.PasswordResetService;
-import com.fliqo.service.dto.request.*;
-import com.fliqo.service.dto.response.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,7 +10,10 @@ import org.springframework.web.server.ResponseStatusException;
 import com.fliqo.controller.dto.request.*;
 import com.fliqo.controller.dto.response.*;
 import com.fliqo.service.MemberService;
+import com.fliqo.service.PasswordResetService;
 import com.fliqo.service.PhoneVerificationService;
+import com.fliqo.service.dto.request.*;
+import com.fliqo.service.dto.response.*;
 import com.fliqo.service.validator.MemberPolicyValidator;
 
 import jakarta.validation.Valid;
@@ -114,27 +114,32 @@ public class MemberController {
 
     @PostMapping("/password/reset/request")
     public ResponseEntity<ApiResponse<PasswordResetStartResult>> requestPasswordReset(
-            @Valid @RequestBody PasswordResetRequest passwordResetRequest
-    ) {
+            @Valid @RequestBody PasswordResetRequest passwordResetRequest) {
         PasswordResetStartResult passwordResetStartResult =
-                passwordResetService.start(PasswordResetStartCommand.of(passwordResetRequest.email(), passwordResetRequest.phoneNumber()));
+                passwordResetService.start(
+                        PasswordResetStartCommand.of(
+                                passwordResetRequest.email(), passwordResetRequest.phoneNumber()));
         return ResponseEntity.ok(ApiResponse.ok(passwordResetStartResult));
     }
 
     @PostMapping("/password/reset/verify")
     public ResponseEntity<ApiResponse<PasswordResetVerifyResult>> verifyPhoneCode(
-            @Valid @RequestBody PasswordResetVerifyRequest passwordResetVerifyRequest
-    ) {
+            @Valid @RequestBody PasswordResetVerifyRequest passwordResetVerifyRequest) {
         PasswordResetVerifyResult passwordResetVerifyResult =
-                passwordResetService.verify(PasswordResetVerifyCommand.of(passwordResetVerifyRequest.verificationId(), passwordResetVerifyRequest.code()));
+                passwordResetService.verify(
+                        PasswordResetVerifyCommand.of(
+                                passwordResetVerifyRequest.verificationId(),
+                                passwordResetVerifyRequest.code()));
         return ResponseEntity.ok(ApiResponse.ok(passwordResetVerifyResult));
     }
 
     @PostMapping("/password/reset/confirm")
     public ResponseEntity<ApiResponse<String>> confirmPasswordReset(
-            @Valid @RequestBody PasswordResetConfirmRequest passwordResetConfirmRequest
-    ) {
-        passwordResetService.confirm(PasswordResetConfirmCommand.of(passwordResetConfirmRequest.resetToken(), passwordResetConfirmRequest.newPassword()));
+            @Valid @RequestBody PasswordResetConfirmRequest passwordResetConfirmRequest) {
+        passwordResetService.confirm(
+                PasswordResetConfirmCommand.of(
+                        passwordResetConfirmRequest.resetToken(),
+                        passwordResetConfirmRequest.newPassword()));
         return ResponseEntity.ok(ApiResponse.ok("새로운 비밀번호로 변경되었습니다."));
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetConfirmRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetConfirmRequest.java
@@ -6,9 +6,8 @@ import jakarta.validation.constraints.Pattern;
 public record PasswordResetConfirmRequest(
         @NotBlank String resetToken,
         @NotBlank
-        @Pattern(
-                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,24}$",
-                message = "영문, 숫자, 특수문자 조합 8~24자로 입력해 주세요."
-        )
-        String newPassword
-) {}
+                @Pattern(
+                        regexp =
+                                "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,24}$",
+                        message = "영문, 숫자, 특수문자 조합 8~24자로 입력해 주세요.")
+                String newPassword) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetConfirmRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetConfirmRequest.java
@@ -2,7 +2,9 @@ package com.fliqo.controller.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
 
+@Builder
 public record PasswordResetConfirmRequest(
         @NotBlank String resetToken,
         @NotBlank

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetConfirmRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetConfirmRequest.java
@@ -1,0 +1,14 @@
+package com.fliqo.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record PasswordResetConfirmRequest(
+        @NotBlank String resetToken,
+        @NotBlank
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,24}$",
+                message = "영문, 숫자, 특수문자 조합 8~24자로 입력해 주세요."
+        )
+        String newPassword
+) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetRequest.java
@@ -1,0 +1,9 @@
+package com.fliqo.controller.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordResetRequest(
+        @NotBlank @Email String email,
+        @NotBlank String phoneNumber
+) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetRequest.java
@@ -3,7 +3,4 @@ package com.fliqo.controller.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record PasswordResetRequest(
-        @NotBlank @Email String email,
-        @NotBlank String phoneNumber
-) {}
+public record PasswordResetRequest(@NotBlank @Email String email, @NotBlank String phoneNumber) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetRequest.java
@@ -2,5 +2,7 @@ package com.fliqo.controller.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record PasswordResetRequest(@NotBlank @Email String email, @NotBlank String phoneNumber) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetVerifyRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetVerifyRequest.java
@@ -1,5 +1,7 @@
 package com.fliqo.controller.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
 
+@Builder
 public record PasswordResetVerifyRequest(@NotBlank String verificationId, @NotBlank String code) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetVerifyRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetVerifyRequest.java
@@ -2,7 +2,4 @@ package com.fliqo.controller.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record PasswordResetVerifyRequest(
-        @NotBlank String verificationId,
-        @NotBlank String code
-) {}
+public record PasswordResetVerifyRequest(@NotBlank String verificationId, @NotBlank String code) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetVerifyRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetVerifyRequest.java
@@ -1,0 +1,8 @@
+package com.fliqo.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordResetVerifyRequest(
+        @NotBlank String verificationId,
+        @NotBlank String code
+) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/entity/MemberCredential.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/entity/MemberCredential.java
@@ -72,6 +72,25 @@ public class MemberCredential {
         return MemberCredential.builder().member(member).passwordHash(passwordHash).build();
     }
 
+    /**
+     * 비밀번호를 변경합니다.
+     *
+     * <p>비밀번호 변경 시 비밀번호 해시는 반드시 <b>이미 암호화된 값</b>이어야 하며, 이 메서드 내에서는 암호화를 수행하지 않습니다. 또한 변경 시 실패 횟수와
+     * 잠금 상태를 초기화하고, 변경 시각을 기록합니다.
+     *
+     * @param encodedPassword 이미 암호화된(해시된) 비밀번호 문자열
+     */
+    public void changePassword(String encodedPassword) {
+        if (encodedPassword == null || encodedPassword.isBlank()) {
+            throw new IllegalArgumentException("비밀번호는 비어 있을 수 없습니다.");
+        }
+
+        this.passwordHash = encodedPassword;
+        this.passwordChangedAt = LocalDateTime.now();
+        this.failedLoginAttempts = 0;
+        this.lockedUntil = null;
+    }
+
     @PrePersist
     void prePersist() {
         if (passwordChangedAt == null) this.passwordChangedAt = LocalDateTime.now();

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/entity/PasswordResetToken.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/entity/PasswordResetToken.java
@@ -1,0 +1,61 @@
+package com.fliqo.domain.entity;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "tb_password_reset_token",
+        indexes = {@Index(name = "idx_prt_token", columnList = "token", unique = true)})
+@Getter
+@NoArgsConstructor
+public class PasswordResetToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 64)
+    private String token;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private Instant expiresAt;
+
+    private Instant usedAt;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Builder
+    private PasswordResetToken(String token, Long memberId, Instant createdAt, Instant expiresAt) {
+        this.token = token;
+        this.memberId = memberId;
+        this.createdAt = createdAt;
+        this.expiresAt = expiresAt;
+    }
+
+    public static PasswordResetToken issue(Long memberId, long ttlSeconds) {
+        Instant now = Instant.now();
+        return PasswordResetToken.builder()
+                .token(UUID.randomUUID().toString().replace("-", ""))
+                .memberId(memberId)
+                .createdAt(now)
+                .expiresAt(now.plusSeconds(ttlSeconds))
+                .build();
+    }
+
+    public boolean isUsable(Instant now) {
+        return usedAt == null && now.isBefore(expiresAt);
+    }
+
+    public void markUsed() {
+        this.usedAt = Instant.now();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/repository/MemberRepository.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByPhone(String phone);
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/repository/PasswordResetTokenRepository.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,11 @@
+package com.fliqo.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.fliqo.domain.entity.PasswordResetToken;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+    Optional<PasswordResetToken> findByToken(String token);
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/JwtService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/JwtService.java
@@ -8,12 +8,11 @@ import java.util.UUID;
 
 import javax.crypto.SecretKey;
 
+import org.springframework.stereotype.Component;
+
 import com.fliqo.config.AuthProperties;
 import com.fliqo.jwt.JwtClaimKeys;
 import com.fliqo.jwt.JwtProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.stereotype.Component;
-
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
@@ -42,15 +41,18 @@ public class JwtService {
         Instant now = Instant.now();
         Instant expirationTime = now.plus(authProperties.accessMin(), ChronoUnit.MINUTES);
 
-        String rolesClaim = jwtProperties.headerInjection() != null
-                && jwtProperties.headerInjection().rolesClaim() != null
-                && !jwtProperties.headerInjection().rolesClaim().isBlank()
-                ? jwtProperties.headerInjection().rolesClaim()
-                : JwtClaimKeys.ROLES;
+        String rolesClaim =
+                jwtProperties.headerInjection() != null
+                                && jwtProperties.headerInjection().rolesClaim() != null
+                                && !jwtProperties.headerInjection().rolesClaim().isBlank()
+                        ? jwtProperties.headerInjection().rolesClaim()
+                        : JwtClaimKeys.ROLES;
 
         return Jwts.builder()
                 .issuer(jwtProperties.issuer())
-                .audience().add(jwtProperties.audience()).and()
+                .audience()
+                .add(jwtProperties.audience())
+                .and()
                 .subject(subjectEmail)
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(expirationTime))

--- a/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
@@ -2,11 +2,11 @@ package com.fliqo.service;
 
 import java.util.List;
 
-import com.fliqo.config.AuthProperties;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fliqo.config.AuthProperties;
 import com.fliqo.controller.dto.response.TokenResponseDto;
 import com.fliqo.domain.entity.Member;
 import com.fliqo.domain.entity.MemberCredential;

--- a/fliqo-member-api/src/main/java/com/fliqo/service/PasswordResetService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/PasswordResetService.java
@@ -1,0 +1,91 @@
+package com.fliqo.service;
+
+import java.time.Instant;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fliqo.domain.entity.Member;
+import com.fliqo.domain.entity.PasswordResetToken;
+import com.fliqo.domain.entity.PhoneVerification;
+import com.fliqo.domain.repository.MemberCredentialRepository;
+import com.fliqo.domain.repository.MemberRepository;
+import com.fliqo.domain.repository.PasswordResetTokenRepository;
+import com.fliqo.service.dto.request.*;
+import com.fliqo.service.dto.response.PasswordResetStartResult;
+import com.fliqo.service.dto.response.PasswordResetVerifyResult;
+import com.fliqo.service.dto.response.PhoneVerificationConfirmResult;
+import com.fliqo.service.dto.response.PhoneVerificationStartResult;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordResetService {
+    private final MemberRepository memberRepository;
+    private final MemberCredentialRepository credentialRepository;
+    private final PasswordResetTokenRepository tokenRepository;
+    private final PhoneVerificationService phoneVerificationService;
+    private final PasswordEncoder passwordEncoder;
+
+    private static final long RESET_TOKEN_TTL_SECONDS = 10 * 60;
+
+    @Transactional
+    public PasswordResetStartResult start(PasswordResetStartCommand passwordResetStartCmd) {
+        var member =
+                memberRepository
+                        .findByEmail(passwordResetStartCmd.email())
+                        .orElseThrow(() -> new IllegalArgumentException("등록되지 않은 이메일입니다."));
+        if (!member.getPhone().equals(passwordResetStartCmd.phoneNumber())) {
+            throw new IllegalArgumentException("등록된 휴대전화와 일치하지 않습니다.");
+        }
+
+        PhoneVerificationStartResult result =
+                phoneVerificationService.start(
+                        PhoneVerificationStartCommand.of(passwordResetStartCmd.phoneNumber()));
+        return PasswordResetStartResult.of(result.verificationId(), result.expiresInMinutes());
+    }
+
+    @Transactional
+    public PasswordResetVerifyResult verify(PasswordResetVerifyCommand passwordResetVerifyCmd) {
+        PhoneVerificationConfirmResult confirmResult =
+                phoneVerificationService.confirm(
+                        PhoneVerificationConfirmCommand.of(
+                                passwordResetVerifyCmd.verificationId(),
+                                passwordResetVerifyCmd.code()));
+
+        PhoneVerification phoneVerification =
+                phoneVerificationService.getByTokenOfThrow(confirmResult.verificationToken());
+
+        Member member =
+                memberRepository
+                        .findByPhone(phoneVerification.getPhoneNumber())
+                        .orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
+
+        var resetToken = PasswordResetToken.issue(member.getId(), RESET_TOKEN_TTL_SECONDS);
+        tokenRepository.save(resetToken);
+
+        phoneVerificationService.consumeToken(phoneVerification);
+
+        return PasswordResetVerifyResult.of(resetToken.getToken(), RESET_TOKEN_TTL_SECONDS);
+    }
+
+    public void confirm(PasswordResetConfirmCommand passwordResetConfirmCmd) {
+        var prt =
+                tokenRepository
+                        .findByToken(passwordResetConfirmCmd.resetToken())
+                        .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 요청입니다."));
+
+        if (!prt.isUsable(Instant.now())) {
+            throw new IllegalArgumentException("만료되었거나 이미 사용된 토큰입니다.");
+        }
+
+        var credential =
+                credentialRepository
+                        .findByMemberId(prt.getMemberId())
+                        .orElseThrow(() -> new IllegalArgumentException("자격 증명을 찾을 수 없습니다."));
+
+        credential.changePassword(passwordEncoder.encode(passwordResetConfirmCmd.newPassword()));
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/PasswordResetService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/PasswordResetService.java
@@ -71,6 +71,7 @@ public class PasswordResetService {
         return PasswordResetVerifyResult.of(resetToken.getToken(), RESET_TOKEN_TTL_SECONDS);
     }
 
+    @Transactional
     public void confirm(PasswordResetConfirmCommand passwordResetConfirmCmd) {
         var prt =
                 tokenRepository

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetConfirmCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetConfirmCommand.java
@@ -1,3 +1,6 @@
 package com.fliqo.service.dto.request;
 
+import lombok.Builder;
+
+@Builder
 public record PasswordResetConfirmCommand(String resetToken, String newPassword) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetConfirmCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetConfirmCommand.java
@@ -3,4 +3,11 @@ package com.fliqo.service.dto.request;
 import lombok.Builder;
 
 @Builder
-public record PasswordResetConfirmCommand(String resetToken, String newPassword) {}
+public record PasswordResetConfirmCommand(String resetToken, String newPassword) {
+    public static PasswordResetConfirmCommand of(String resetToken, String newPassword) {
+        return PasswordResetConfirmCommand.builder()
+                .resetToken(resetToken)
+                .newPassword(newPassword)
+                .build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetConfirmCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetConfirmCommand.java
@@ -1,0 +1,3 @@
+package com.fliqo.service.dto.request;
+
+public record PasswordResetConfirmCommand(String resetToken, String newPassword) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetStartCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetStartCommand.java
@@ -1,0 +1,3 @@
+package com.fliqo.service.dto.request;
+
+public record PasswordResetStartCommand(String email, String phoneNumber) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetStartCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetStartCommand.java
@@ -3,4 +3,11 @@ package com.fliqo.service.dto.request;
 import lombok.Builder;
 
 @Builder
-public record PasswordResetStartCommand(String email, String phoneNumber) {}
+public record PasswordResetStartCommand(String email, String phoneNumber) {
+    public static PasswordResetStartCommand of(String email, String phoneNumber) {
+        return PasswordResetStartCommand.builder()
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetStartCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetStartCommand.java
@@ -5,9 +5,6 @@ import lombok.Builder;
 @Builder
 public record PasswordResetStartCommand(String email, String phoneNumber) {
     public static PasswordResetStartCommand of(String email, String phoneNumber) {
-        return PasswordResetStartCommand.builder()
-                .email(email)
-                .phoneNumber(phoneNumber)
-                .build();
+        return PasswordResetStartCommand.builder().email(email).phoneNumber(phoneNumber).build();
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetStartCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetStartCommand.java
@@ -1,3 +1,6 @@
 package com.fliqo.service.dto.request;
 
+import lombok.Builder;
+
+@Builder
 public record PasswordResetStartCommand(String email, String phoneNumber) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetVerifyCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetVerifyCommand.java
@@ -3,4 +3,11 @@ package com.fliqo.service.dto.request;
 import lombok.Builder;
 
 @Builder
-public record PasswordResetVerifyCommand(String verificationId, String code) {}
+public record PasswordResetVerifyCommand(String verificationId, String code) {
+    public static PasswordResetVerifyCommand of(String verificationId, String code) {
+        return PasswordResetVerifyCommand.builder()
+                .verificationId(verificationId)
+                .code(code)
+                .build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetVerifyCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetVerifyCommand.java
@@ -1,3 +1,6 @@
 package com.fliqo.service.dto.request;
 
+import lombok.Builder;
+
+@Builder
 public record PasswordResetVerifyCommand(String verificationId, String code) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetVerifyCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetVerifyCommand.java
@@ -1,0 +1,3 @@
+package com.fliqo.service.dto.request;
+
+public record PasswordResetVerifyCommand(String verificationId, String code) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/PasswordResetStartResult.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/PasswordResetStartResult.java
@@ -1,3 +1,7 @@
 package com.fliqo.service.dto.response;
 
-public record PasswordResetStartResult(String verificationId, long expiresInSeconds) {}
+public record PasswordResetStartResult(String verificationId, long expiresInSeconds) {
+    public static PasswordResetStartResult of(String verificationId, long expiresInSeconds) {
+        return new PasswordResetStartResult(verificationId, expiresInSeconds);
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/PasswordResetStartResult.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/PasswordResetStartResult.java
@@ -1,0 +1,3 @@
+package com.fliqo.service.dto.response;
+
+public record PasswordResetStartResult(String verificationId, long expiresInSeconds) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/PasswordResetStartResult.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/PasswordResetStartResult.java
@@ -1,7 +1,13 @@
 package com.fliqo.service.dto.response;
 
+import lombok.Builder;
+
+@Builder
 public record PasswordResetStartResult(String verificationId, long expiresInSeconds) {
     public static PasswordResetStartResult of(String verificationId, long expiresInSeconds) {
-        return new PasswordResetStartResult(verificationId, expiresInSeconds);
+        return PasswordResetStartResult.builder()
+                .verificationId(verificationId)
+                .expiresInSeconds(expiresInSeconds)
+                .build();
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/PasswordResetVerifyResult.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/PasswordResetVerifyResult.java
@@ -1,3 +1,13 @@
 package com.fliqo.service.dto.response;
 
-public record PasswordResetVerifyResult(String resetToken, long expiresInSeconds) {}
+import lombok.Builder;
+
+@Builder
+public record PasswordResetVerifyResult(String resetToken, long expiresInSeconds) {
+    public static PasswordResetVerifyResult of(String resetToken, long expiresInSeconds) {
+        return PasswordResetVerifyResult.builder()
+                .resetToken(resetToken)
+                .expiresInSeconds(expiresInSeconds)
+                .build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/PasswordResetVerifyResult.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/PasswordResetVerifyResult.java
@@ -1,0 +1,3 @@
+package com.fliqo.service.dto.response;
+
+public record PasswordResetVerifyResult(String resetToken, long expiresInSeconds) {}


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 비밀번호 재설정(비밀번호 찾기) API를 신규로 구축하여, 이메일 + 휴대전화 인증을 통해 사용자가 본인임을 검증한 뒤 비밀번호를 안전하게 변경할 수 있도록 함.
- `PasswordResetService`
 추가 및 관련 엔티티(`MemberCredential` `PasswordResetToken`) 기능 확장
## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- `MemberController` 추가
  - `/api/member/password/reset/request` : 이메일/휴대폰 입력 및 인증번호 발송
  - `/api/member/password/reset/verify` : 인증번호 검증 및 resetToken 발급
  - `/api/member/password/reset/confirm` : 토큰 기반 비밀번호 재설정
- `PasswordResetService` 구현
  - start / verify / confirm 세 단계 로직 분리
  - 비밀번호 변경(`MemberCredential.changePassword`) 시 비밀번호 DB Update
- DTO 구조 통일 (`Command`, `Result`)
  - 모든 DTO에 `builder()` + `of()` 정적 팩토리 메서드 추가
- `MemberCredential` 엔티티에 changePassword()` 메서드 추가
- 게이트웨이 보안 설정 수정
  - `/api/member/password/reset/**` 경로를 `permitAll` 처리
- 전화번호 기반 중복 조회 오류 수정 (`findByPhone`)
## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. GatewayApplication -> MemberApplication -> CoreApplication 실행
2. SwaggerUI 기반 비밀번호 재설정 (request -> verify -> confirm)
3. 재설정 비밀번호로 로그인 시도

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #37 
