### PR TITLE
Add email recovery API with phone verification

### DIFF
--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -9,6 +9,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import com.fliqo.controller.dto.request.*;
 import com.fliqo.controller.dto.response.*;
+import com.fliqo.service.EmailFindService;
 import com.fliqo.service.MemberService;
 import com.fliqo.service.PasswordResetService;
 import com.fliqo.service.PhoneVerificationService;
@@ -27,6 +28,7 @@ public class MemberController {
     private final PhoneVerificationService phoneVerificationService;
     private final MemberPolicyValidator memberPolicyValidator;
     private final PasswordResetService passwordResetService;
+    private final EmailFindService emailFindService;
 
     @PostMapping("/email-check")
     public ResponseEntity<ApiResponse<EmailCheckResponse>> check(
@@ -64,6 +66,39 @@ public class MemberController {
                 ApiResponse.ok(
                         PhoneVerifyConfirmResponse.of(
                                 phoneVerificationConfirmResult.verificationToken())));
+    }
+
+    @PostMapping("/email/find/request")
+    public ResponseEntity<ApiResponse<EmailFindStartResponse>> requestEmailFind(
+            @Valid @RequestBody EmailFindStartRequest emailFindStartRequest) {
+        EmailFindStartResult emailFindStartResult =
+                emailFindService.start(EmailFindStartCommand.of(emailFindStartRequest.phoneNumber()));
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(
+                        EmailFindStartResponse.of(
+                                emailFindStartResult.verificationId(),
+                                emailFindStartResult.expiresInMinutes())));
+    }
+
+    @PostMapping("/email/find/verify")
+    public ResponseEntity<ApiResponse<EmailFindVerifyResponse>> verifyEmailFind(
+            @Valid @RequestBody EmailFindVerifyRequest emailFindVerifyRequest) {
+        EmailFindResult emailFindResult =
+                emailFindService.verify(
+                        EmailFindVerifyCommand.of(
+                                emailFindVerifyRequest.verificationId(),
+                                emailFindVerifyRequest.code()));
+
+        String message =
+                emailFindResult.found()
+                        ? String.format("등록된 이메일은 %s 입니다.", emailFindResult.maskedEmail())
+                        : "등록된 회원정보가 없습니다.";
+
+        return ResponseEntity.ok(
+                ApiResponse.ok(
+                        EmailFindVerifyResponse.of(
+                                emailFindResult.found(), emailFindResult.maskedEmail(), message)));
     }
 
     @PostMapping("/signup")

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/EmailFindStartRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/EmailFindStartRequest.java
@@ -1,0 +1,11 @@
+package com.fliqo.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record EmailFindStartRequest(
+        @NotBlank
+                @Pattern(
+                        regexp = "^01[016789]-\\d{3,4}-\\d{4}$",
+                        message = "올바른 휴대폰 번호 형식이 아닙니다")
+                String phoneNumber) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/EmailFindVerifyRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/EmailFindVerifyRequest.java
@@ -1,0 +1,7 @@
+package com.fliqo.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailFindVerifyRequest(
+        @NotBlank String verificationId,
+        @NotBlank String code) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/response/EmailFindStartResponse.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/response/EmailFindStartResponse.java
@@ -1,0 +1,13 @@
+package com.fliqo.controller.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record EmailFindStartResponse(String verificationId, long expiresInMinutes) {
+    public static EmailFindStartResponse of(String verificationId, long expiresInMinutes) {
+        return EmailFindStartResponse.builder()
+                .verificationId(verificationId)
+                .expiresInMinutes(expiresInMinutes)
+                .build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/response/EmailFindVerifyResponse.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/response/EmailFindVerifyResponse.java
@@ -1,0 +1,14 @@
+package com.fliqo.controller.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record EmailFindVerifyResponse(boolean found, String maskedEmail, String message) {
+    public static EmailFindVerifyResponse of(boolean found, String maskedEmail, String message) {
+        return EmailFindVerifyResponse.builder()
+                .found(found)
+                .maskedEmail(maskedEmail)
+                .message(message)
+                .build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/EmailFindService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/EmailFindService.java
@@ -1,0 +1,77 @@
+package com.fliqo.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fliqo.domain.entity.Member;
+import com.fliqo.domain.entity.PhoneVerification;
+import com.fliqo.domain.repository.MemberRepository;
+import com.fliqo.service.dto.request.EmailFindStartCommand;
+import com.fliqo.service.dto.request.EmailFindVerifyCommand;
+import com.fliqo.service.dto.request.PhoneVerificationConfirmCommand;
+import com.fliqo.service.dto.request.PhoneVerificationStartCommand;
+import com.fliqo.service.dto.response.EmailFindResult;
+import com.fliqo.service.dto.response.EmailFindStartResult;
+import com.fliqo.service.dto.response.PhoneVerificationConfirmResult;
+import com.fliqo.service.dto.response.PhoneVerificationStartResult;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EmailFindService {
+
+    private final MemberRepository memberRepository;
+    private final PhoneVerificationService phoneVerificationService;
+
+    @Transactional
+    public EmailFindStartResult start(EmailFindStartCommand emailFindStartCmd) {
+        PhoneVerificationStartResult startResult =
+                phoneVerificationService.start(
+                        PhoneVerificationStartCommand.of(emailFindStartCmd.phoneNumber()));
+
+        return EmailFindStartResult.of(startResult.verificationId(), startResult.expiresInMinutes());
+    }
+
+    @Transactional
+    public EmailFindResult verify(EmailFindVerifyCommand emailFindVerifyCmd) {
+        PhoneVerificationConfirmResult confirmResult =
+                phoneVerificationService.confirm(
+                        PhoneVerificationConfirmCommand.of(
+                                emailFindVerifyCmd.verificationId(), emailFindVerifyCmd.code()));
+
+        PhoneVerification phoneVerification =
+                phoneVerificationService.getByTokenOfThrow(confirmResult.verificationToken());
+
+        EmailFindResult result =
+                memberRepository
+                        .findByPhone(phoneVerification.getPhoneNumber())
+                        .map(Member::getEmail)
+                        .map(this::maskEmail)
+                        .map(EmailFindResult::found)
+                        .orElseGet(EmailFindResult::notFound);
+
+        phoneVerificationService.consumeToken(phoneVerification);
+
+        return result;
+    }
+
+    private String maskEmail(String email) {
+        int atIndex = email.indexOf('@');
+        if (atIndex <= 0) {
+            return "***";
+        }
+
+        String localPart = email.substring(0, atIndex);
+        String domainPart = email.substring(atIndex);
+
+        if (localPart.length() <= 2) {
+            return localPart.substring(0, 1) + "***" + domainPart;
+        }
+
+        int visibleCount = Math.min(3, localPart.length());
+        String visible = localPart.substring(0, visibleCount);
+        String masked = "*".repeat(Math.max(1, localPart.length() - visibleCount));
+        return visible + masked + domainPart;
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/EmailFindStartCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/EmailFindStartCommand.java
@@ -1,0 +1,7 @@
+package com.fliqo.service.dto.request;
+
+public record EmailFindStartCommand(String phoneNumber) {
+    public static EmailFindStartCommand of(String phoneNumber) {
+        return new EmailFindStartCommand(phoneNumber);
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/EmailFindVerifyCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/EmailFindVerifyCommand.java
@@ -1,0 +1,7 @@
+package com.fliqo.service.dto.request;
+
+public record EmailFindVerifyCommand(String verificationId, String code) {
+    public static EmailFindVerifyCommand of(String verificationId, String code) {
+        return new EmailFindVerifyCommand(verificationId, code);
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/EmailFindResult.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/EmailFindResult.java
@@ -1,0 +1,14 @@
+package com.fliqo.service.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record EmailFindResult(boolean found, String maskedEmail) {
+    public static EmailFindResult found(String maskedEmail) {
+        return EmailFindResult.builder().found(true).maskedEmail(maskedEmail).build();
+    }
+
+    public static EmailFindResult notFound() {
+        return EmailFindResult.builder().found(false).maskedEmail(null).build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/EmailFindStartResult.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/EmailFindStartResult.java
@@ -1,0 +1,13 @@
+package com.fliqo.service.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record EmailFindStartResult(String verificationId, long expiresInMinutes) {
+    public static EmailFindStartResult of(String verificationId, long expiresInMinutes) {
+        return EmailFindStartResult.builder()
+                .verificationId(verificationId)
+                .expiresInMinutes(expiresInMinutes)
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- add endpoints under `/api/member/email/find` to request and verify phone codes before revealing the masked email address
- implement service- and controller-level DTOs plus `EmailFindService` to coordinate phone verification, masking, and repository lookup

## Testing
- ./gradlew :fliqo-member-api:test *(fails: toolchain for Java 17 is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690165747f50832b999cb76b56ccafb0