### PR TITLE
chore: PostgreSQL 마이그레이션 및 OpenApiConfig 모듈 통합

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
         implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 
-        runtimeOnly 'com.mysql:mysql-connector-j'
+        runtimeOnly 'org.postgresql:postgresql'
 
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'

--- a/fliqo-common/build.gradle
+++ b/fliqo-common/build.gradle
@@ -14,6 +14,8 @@ dependencies {
 
     api 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
 
+    api 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+
     compileOnly 'org.springframework.boot:spring-boot'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 

--- a/fliqo-common/src/main/java/com/fliqo/config/OpenApiConfig.java
+++ b/fliqo-common/src/main/java/com/fliqo/config/OpenApiConfig.java
@@ -20,7 +20,7 @@ public class OpenApiConfig {
         final String SCHEME = "bearerAuth";
 
         return new OpenAPI()
-                // 게이트웨이를 경유해 호출되도록 서버 URL을 gateway로 지정 (로컬 기준)
+                // 게이트웨이를 경유해 호출되도록 서버 URL을 gateway로 지정
                 .servers(
                         List.of(
                                 new Server()

--- a/fliqo-core-api/build.gradle
+++ b/fliqo-core-api/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     implementation project(':fliqo-common')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
 }

--- a/fliqo-core-api/src/main/resources/application.yml
+++ b/fliqo-core-api/src/main/resources/application.yml
@@ -1,6 +1,27 @@
 server:
   port: 8082
   forward-headers-strategy: framework
+
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none  # 네이티브 쿼리만 사용하므로 DDL 자동 생성 비활성화
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/fliqo-member-api/build.gradle
+++ b/fliqo-member-api/build.gradle
@@ -7,8 +7,6 @@ dependencies {
     // OAuth2 소셜 로그인 (카카오, 네이버 등)
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
-
     // JWT 생성
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/fliqo-member-api/src/main/resources/application.yml
+++ b/fliqo-member-api/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: org.postgresql.Driver
 
   jpa:
     hibernate:
@@ -18,9 +18,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MySQL8Dialect
-    database: mysql
-    database-platform: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
MySQL에서 PostgreSQL로 데이터베이스를 마이그레이션하고, OpenApiConfig를 common 모듈로 이동하여 중복을 제거하고 공통 설정을 통합

- root `build.gradle`에서 MySQL 의존성을 PostgreSQL로 변경
- member-api와 core-api 모듈의 DB 설정을 PostgreSQL로 변경/추가
- OpenApiConfig를 common 모듈로 이동하여 중복 제거 및 의존성 정리

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
### 1. 데이터베이스 마이그레이션
- 루트 `build.gradle`: `com.mysql:mysql-connector-j` → `org.postgresql:postgresql`로 의존성 변경
- member-api `application.yml`: MySQL 설정을 PostgreSQL로 변경
  - `driver-class-name`: `com.mysql.cj.jdbc.Driver` → `org.postgresql.Driver`
  - `dialect`: `MySQL8Dialect` → `PostgreSQLDialect`
  - `database`: `mysql` → `postgresql`
- core-api `application.yml`: PostgreSQL DB 설정 추가
  - `ddl-auto: none` 설정 (네이티브 쿼리 사용)
  - PostgreSQL 드라이버 설정

### 2. OpenApiConfig 공통화
- OpenApiConfig 파일 이동: `fliqo-member-api` → `fliqo-common` 모듈로 이동
- 의존성 정리:
  - `fliqo-common/build.gradle`: OpenAPI 의존성 추가 (`api`로 제공)
  - `fliqo-member-api/build.gradle`: OpenAPI 의존성 제거 (common에서 제공)
  - `fliqo-core-api/build.gradle`: OpenAPI 의존성 제거 (common에서 제공)

### 3. 추가 변경사항
- core-api `build.gradle`: JPA 의존성 추가 (`spring-boot-starter-data-jpa`)


## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. 빌드 테스트
   `./gradlew clean build`: 모든 모듈이 정상적으로 빌드되는지 확인
2. 애플리케이션 실행 테스트 (로컬 환경 실행)
   `./dev-script/run-local.sh`
      - Gateway(8080), Member API(8081), Core API(8082)가 순서대로 실행되는지 확인
   - 로그 파일 확인: `dev-script/logs/*.log`
     - `dev-script/logs/fliqo-gateway.log`
     - `dev-script/logs/fliqo-member-api.log`
     - `dev-script/logs/fliqo-core-api.log`
   - 로그에서 PostgreSQL 드라이버가 정상적으로 로드되는지 확인
   - PostgreSQL 연결이 성공하는지 확인 (에러 없이 시작되는지)
3. 데이터베이스 연결 테스트
   - 각 모듈에서 실제 DB 쿼리가 정상적으로 실행되는지 확인
4. 애플리케이션 종료
   `./dev-script/stop-local.sh`
      - 모든 모듈이 정상적으로 종료되는지 확인

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #
