### PR TITLE
이메일 찾기 api 추가 및 휴대폰 인증 목적 추가

### DIFF
--- a/fliqo-gateway/src/main/java/com/fliqo/config/SecurityConfig.java
+++ b/fliqo-gateway/src/main/java/com/fliqo/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                                         "/api/member/signup",
                                         "/api/member/email-check",
                                         "/api/member/phone/**",
-                                        "/api/member/password/reset/**")
+                                        "/api/member/password/reset/**",
+                                        "/api/member/email/find/**")
                                 .permitAll()
                                 .pathMatchers("/swagger-ui.html", "/swagger-ui/**")
                                 .permitAll()

--- a/fliqo-member-api/src/main/java/com/fliqo/config/SecurityConfig.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
                                                 "/api/member/phone/**",
                                                 "/api/member/signup",
                                                 "/api/member/login",
-                                                "/api/member/password/reset/**")
+                                                "/api/member/password/reset/**",
+                                                "/api/member/email/find/**")
                                         .permitAll()
                                         .requestMatchers(HttpMethod.GET, "/api/member/me")
                                         .permitAll()

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -42,8 +42,7 @@ public class MemberController {
                 phoneVerificationService.start(
                         PhoneVerificationStartCommand.of(
                                 phoneVerifyStartRequest.phoneNumber(),
-                                phoneVerifyStartRequest.purpose()
-                        ));
+                                phoneVerifyStartRequest.purpose()));
         return ResponseEntity.ok(
                 CommonResponse.success(
                         PhoneVerifyRequestResponse.of(
@@ -108,8 +107,7 @@ public class MemberController {
                         PasswordResetStartCommand.of(
                                 passwordResetStartRequest.email(),
                                 passwordResetStartRequest.phoneNumber(),
-                                passwordResetStartRequest.purpose()
-                                ));
+                                passwordResetStartRequest.purpose()));
         return ResponseEntity.ok(CommonResponse.success(passwordResetStartResult));
     }
 
@@ -141,8 +139,7 @@ public class MemberController {
                 phoneVerificationService.start(
                         PhoneVerificationStartCommand.of(
                                 phoneVerifyStartRequest.phoneNumber(),
-                                phoneVerifyStartRequest.purpose()
-                        ));
+                                phoneVerifyStartRequest.purpose()));
 
         return ResponseEntity.ok(
                 CommonResponse.success(

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -40,7 +40,10 @@ public class MemberController {
             @Valid @RequestBody PhoneVerifyStartRequest phoneVerifyStartRequest) {
         PhoneVerificationStartResult phoneVerificationStartResult =
                 phoneVerificationService.start(
-                        PhoneVerificationStartCommand.of(phoneVerifyStartRequest.phoneNumber()));
+                        PhoneVerificationStartCommand.of(
+                                phoneVerifyStartRequest.phoneNumber(),
+                                phoneVerifyStartRequest.purpose()
+                        ));
         return ResponseEntity.ok(
                 CommonResponse.success(
                         PhoneVerifyRequestResponse.of(
@@ -99,11 +102,14 @@ public class MemberController {
 
     @PostMapping("/password/reset/request")
     public ResponseEntity<CommonResponse<PasswordResetStartResult>> requestPasswordReset(
-            @Valid @RequestBody PasswordResetRequest passwordResetRequest) {
+            @Valid @RequestBody PasswordResetStartRequest passwordResetStartRequest) {
         PasswordResetStartResult passwordResetStartResult =
                 passwordResetService.start(
                         PasswordResetStartCommand.of(
-                                passwordResetRequest.email(), passwordResetRequest.phoneNumber()));
+                                passwordResetStartRequest.email(),
+                                passwordResetStartRequest.phoneNumber(),
+                                passwordResetStartRequest.purpose()
+                                ));
         return ResponseEntity.ok(CommonResponse.success(passwordResetStartResult));
     }
 
@@ -126,5 +132,36 @@ public class MemberController {
                         passwordResetConfirmRequest.resetToken(),
                         passwordResetConfirmRequest.newPassword()));
         return ResponseEntity.ok(CommonResponse.success("새로운 비밀번호로 변경되었습니다."));
+    }
+
+    @PostMapping("email/find/request")
+    public ResponseEntity<CommonResponse<PhoneVerifyRequestResponse>> emailFindRequest(
+            @Valid @RequestBody PhoneVerifyStartRequest phoneVerifyStartRequest) {
+        PhoneVerificationStartResult phoneVerificationStartResult =
+                phoneVerificationService.start(
+                        PhoneVerificationStartCommand.of(
+                                phoneVerifyStartRequest.phoneNumber(),
+                                phoneVerifyStartRequest.purpose()
+                        ));
+
+        return ResponseEntity.ok(
+                CommonResponse.success(
+                        PhoneVerifyRequestResponse.of(
+                                phoneVerificationStartResult.verificationId(),
+                                phoneVerificationStartResult.expiresInMinutes())));
+    }
+
+    @PostMapping("email/find/confirm")
+    public ResponseEntity<CommonResponse<EmailFindConfirmResponse>> emailFindConfirm(
+            @Valid @RequestBody EmailFindConfirmRequest emailFindVerifyRequest) {
+        EmailFindConfirmResult emailFindConfirmResult =
+                memberService.emailFindByPhone(
+                        EmailFindConfirmCommand.of(
+                                emailFindVerifyRequest.verificationId(),
+                                emailFindVerifyRequest.code()));
+
+        return ResponseEntity.ok(
+                CommonResponse.success(
+                        EmailFindConfirmResponse.of(emailFindConfirmResult.maskedEmail())));
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/EmailFindConfirmRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/EmailFindConfirmRequest.java
@@ -1,0 +1,7 @@
+package com.fliqo.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record EmailFindConfirmRequest(@NotBlank String verificationId, @NotBlank String code) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetRequest.java
@@ -1,8 +1,0 @@
-package com.fliqo.controller.dto.request;
-
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import lombok.Builder;
-
-@Builder
-public record PasswordResetRequest(@NotBlank @Email String email, @NotBlank String phoneNumber) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetStartRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PasswordResetStartRequest.java
@@ -1,0 +1,14 @@
+package com.fliqo.controller.dto.request;
+
+import com.fliqo.domain.entity.PhoneVerificationPurpose;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record PasswordResetStartRequest(
+        @NotBlank @Email String email,
+        @NotBlank String phoneNumber,
+        @NotNull PhoneVerificationPurpose purpose) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PhoneVerifyStartRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/PhoneVerifyStartRequest.java
@@ -1,8 +1,12 @@
 package com.fliqo.controller.dto.request;
 
+import com.fliqo.domain.entity.PhoneVerificationPurpose;
+
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public record PhoneVerifyStartRequest(
         @NotBlank @Pattern(regexp = "^01[016789]-\\d{3,4}-\\d{4}$", message = "올바른 휴대폰 번호 형식이 아닙니다")
-                String phoneNumber) {}
+                String phoneNumber,
+        @NotNull PhoneVerificationPurpose purpose) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/response/EmailFindConfirmResponse.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/response/EmailFindConfirmResponse.java
@@ -1,0 +1,14 @@
+package com.fliqo.controller.dto.response;
+
+import lombok.Builder;
+
+public record EmailFindConfirmResponse(String maskedEmail) {
+    @Builder
+    public EmailFindConfirmResponse {}
+
+    public static EmailFindConfirmResponse of(String maskedEmail) {
+        return EmailFindConfirmResponse.builder()
+                .maskedEmail(maskedEmail)
+                .build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/response/EmailFindConfirmResponse.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/response/EmailFindConfirmResponse.java
@@ -7,8 +7,6 @@ public record EmailFindConfirmResponse(String maskedEmail) {
     public EmailFindConfirmResponse {}
 
     public static EmailFindConfirmResponse of(String maskedEmail) {
-        return EmailFindConfirmResponse.builder()
-                .maskedEmail(maskedEmail)
-                .build();
+        return EmailFindConfirmResponse.builder().maskedEmail(maskedEmail).build();
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/entity/MemberCredential.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/entity/MemberCredential.java
@@ -18,7 +18,7 @@ public class MemberCredential {
     @Column(name = "member_id")
     private Long memberId;
 
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.LAZY, optional = false, cascade = CascadeType.PERSIST)
     @MapsId
     @JoinColumn(name = "member_id")
     private Member member;

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/entity/PhoneVerification.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/entity/PhoneVerification.java
@@ -51,6 +51,9 @@ public class PhoneVerification {
     @Column(name = "attempts", nullable = false)
     private int attempts;
 
+    @Column(name = "purpose", nullable = false)
+    private Integer purpose;
+
     /**
      * 새로운 휴대폰 인증 엔티티를 생성합니다.
      *
@@ -62,11 +65,13 @@ public class PhoneVerification {
      * @param code 발송할 인증 코드(6자리)
      * @return 생성된 {@link PhoneVerification} 엔티티
      */
-    public static PhoneVerification createNew(String phoneNumber, String code) {
+    public static PhoneVerification createNew(
+            String phoneNumber, String code, PhoneVerificationPurpose purpose) {
         LocalDateTime now = LocalDateTime.now();
         return PhoneVerification.builder()
                 .id(UuidUtil.newUuid())
                 .phoneNumber(phoneNumber)
+                .purpose(purpose.getCode())
                 .code(code)
                 .expiresAt(now.plusMinutes(DEFAULT_EXPIRY_MINUTES))
                 .attempts(0)

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/entity/PhoneVerification.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/entity/PhoneVerification.java
@@ -51,7 +51,7 @@ public class PhoneVerification {
     @Column(name = "attempts", nullable = false)
     private int attempts;
 
-    @Column(name = "purpose", nullable = false)
+    @Column(name = "purpose")
     private Integer purpose;
 
     /**

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/entity/PhoneVerificationPurpose.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/entity/PhoneVerificationPurpose.java
@@ -1,0 +1,26 @@
+package com.fliqo.domain.entity;
+
+import java.util.Arrays;
+
+public enum PhoneVerificationPurpose {
+    SIGNUP(0),
+    FIND_EMAIL(1),
+    PASSWORD_RESET(2);
+
+    private final int code;
+
+    PhoneVerificationPurpose(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public static PhoneVerificationPurpose fromCode(int code) {
+        return Arrays.stream(values())
+                .filter(v -> v.code == code)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown code : " + code));
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
@@ -56,22 +56,12 @@ public class MemberService {
      */
     @Transactional
     public SignupResult signup(SignupCommand signupCmd) {
-        log.info("Step 1: Validate email");
         validateSignupRequest(signupCmd);
-
-        log.info("Step 2: Verify phone");
         PhoneVerification phoneVerification = verifyPhone(signupCmd);
-
-        log.info("Step 3: Create member");
         Member member = createMember(signupCmd);
-
-        log.info("Step 4: Create credential");
         createCredential(member, signupCmd.rawPassword());
-
-        log.info("Step 5: Consume token");
         phoneVerificationService.consumeToken(phoneVerification);
 
-        log.info("Step 6: Build result");
         return buildSignupResult(member);
     }
 
@@ -106,7 +96,6 @@ public class MemberService {
      * @return 저장된 Member 엔티티
      */
     private Member createMember(SignupCommand signupCmd) {
-        log.info("=== Step 3 시작 ===");
         Member member =
                 Member.builder()
                         .memberUuid(UuidUtil.newUuid())
@@ -122,12 +111,9 @@ public class MemberService {
                         .locale("ko-KR")
                         .build();
 
-        log.info("Member 객체 생성 완료, 저장 시작...");
         Member savedMember = memberRepository.save(member);
-        log.info("save() 호출 완료, ID: {}", savedMember.getId());
 
         memberRepository.flush(); // ✅ 추가
-        log.info("flush() 완료, ID: {}", savedMember.getId());
 
         return savedMember;
     }
@@ -139,22 +125,9 @@ public class MemberService {
      * @param rawPassword 암호화되지 않은 평문 비밀번호
      */
     private void createCredential(Member member, String rawPassword) {
-        log.info("=== Step 4 시작 ===");
-        log.info("Member ID: {}", member.getId());
-        log.info("Member UUID: {}", member.getMemberUuid());
-        log.info("Member Email: {}", member.getEmail());
-
-        if (member.getId() == null) {
-            log.error("❌❌❌ Member ID is NULL! Member was not flushed! ❌❌❌");
-        }
-
-        log.info("Password encoding 시작...");
         long startTime = System.currentTimeMillis();
         String hash = passwordEncoder.encode(rawPassword);
         long endTime = System.currentTimeMillis();
-        log.info("Password encoding 완료. 소요시간: {}ms", (endTime - startTime));
-
-        log.info("MemberCredential 객체 생성 중...");
         MemberCredential credential =
                 MemberCredential.builder()
                         .member(member)
@@ -163,11 +136,7 @@ public class MemberService {
                         .failedLoginAttempts(0)
                         .passwordChangedAt(LocalDateTime.now())
                         .build();
-        log.info("MemberCredential 객체 생성 완료");
-
-        log.info("DB 저장 시작...");
         credentialRepository.save(credential);
-        log.info("DB 저장 완료!");
     }
 
     /**

--- a/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
@@ -1,16 +1,20 @@
 package com.fliqo.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fliqo.domain.entity.*;
+import com.fliqo.exception.BadRequestException;
+import com.fliqo.service.dto.request.EmailFindConfirmCommand;
+import com.fliqo.service.dto.request.PhoneVerificationConfirmCommand;
+import com.fliqo.service.dto.response.EmailFindConfirmResult;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fliqo.config.AuthProperties;
 import com.fliqo.controller.dto.response.TokenResponseDto;
-import com.fliqo.domain.entity.Member;
-import com.fliqo.domain.entity.MemberCredential;
-import com.fliqo.domain.entity.PhoneVerification;
 import com.fliqo.domain.repository.MemberCredentialRepository;
 import com.fliqo.domain.repository.MemberRepository;
 import com.fliqo.exception.ErrorCode;
@@ -24,6 +28,7 @@ import com.fliqo.util.UuidUtil;
 
 import lombok.RequiredArgsConstructor;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -51,12 +56,22 @@ public class MemberService {
      */
     @Transactional
     public SignupResult signup(SignupCommand signupCmd) {
+        log.info("Step 1: Validate email");
         validateSignupRequest(signupCmd);
+
+        log.info("Step 2: Verify phone");
         PhoneVerification phoneVerification = verifyPhone(signupCmd);
+
+        log.info("Step 3: Create member");
         Member member = createMember(signupCmd);
+
+        log.info("Step 4: Create credential");
         createCredential(member, signupCmd.rawPassword());
+
+        log.info("Step 5: Consume token");
         phoneVerificationService.consumeToken(phoneVerification);
 
+        log.info("Step 6: Build result");
         return buildSignupResult(member);
     }
 
@@ -91,14 +106,29 @@ public class MemberService {
      * @return 저장된 Member 엔티티
      */
     private Member createMember(SignupCommand signupCmd) {
-        Member member =
-                Member.builder()
-                        .memberUuid(UuidUtil.newUuid())
-                        .email(signupCmd.email())
-                        .name(signupCmd.name())
-                        .phone(signupCmd.phoneNumber())
-                        .build();
-        return memberRepository.save(member);
+        log.info("=== Step 3 시작 ===");
+        Member member = Member.builder()
+                .memberUuid(UuidUtil.newUuid())
+                .email(signupCmd.email())
+                .name(signupCmd.name())
+                .phone(signupCmd.phoneNumber())
+                .role(Role.USER)
+                .status(MemberStatus.ACTIVE)
+                .emailVerified(false)
+                .phoneVerified(false)
+                .ownerVerified(false)
+                .onboardingStep((short) 0)
+                .locale("ko-KR")
+                .build();
+
+        log.info("Member 객체 생성 완료, 저장 시작...");
+        Member savedMember = memberRepository.save(member);
+        log.info("save() 호출 완료, ID: {}", savedMember.getId());
+
+        memberRepository.flush();  // ✅ 추가
+        log.info("flush() 완료, ID: {}", savedMember.getId());
+
+        return savedMember;
     }
 
     /**
@@ -108,9 +138,34 @@ public class MemberService {
      * @param rawPassword 암호화되지 않은 평문 비밀번호
      */
     private void createCredential(Member member, String rawPassword) {
+        log.info("=== Step 4 시작 ===");
+        log.info("Member ID: {}", member.getId());
+        log.info("Member UUID: {}", member.getMemberUuid());
+        log.info("Member Email: {}", member.getEmail());
+
+        if (member.getId() == null) {
+            log.error("❌❌❌ Member ID is NULL! Member was not flushed! ❌❌❌");
+        }
+
+        log.info("Password encoding 시작...");
+        long startTime = System.currentTimeMillis();
         String hash = passwordEncoder.encode(rawPassword);
-        MemberCredential credential = MemberCredential.createNew(member, hash);
+        long endTime = System.currentTimeMillis();
+        log.info("Password encoding 완료. 소요시간: {}ms", (endTime - startTime));
+
+        log.info("MemberCredential 객체 생성 중...");
+        MemberCredential credential = MemberCredential.builder()
+                .member(member)
+                .passwordHash(hash)
+                .passwordAlgo(PasswordAlgo.BCRYPT)
+                .failedLoginAttempts(0)
+                .passwordChangedAt(LocalDateTime.now())
+                .build();
+        log.info("MemberCredential 객체 생성 완료");
+
+        log.info("DB 저장 시작...");
         credentialRepository.save(credential);
+        log.info("DB 저장 완료!");
     }
 
     /**
@@ -200,5 +255,37 @@ public class MemberService {
      */
     private long calculateExpirationSeconds() {
         return authProperties.accessMin() * 60;
+    }
+
+    @Transactional
+    public EmailFindConfirmResult emailFindByPhone(EmailFindConfirmCommand emailFindConfirmCommand) {
+        PhoneVerification phoneVerification =
+                phoneVerificationService.verifyAndGet(
+                        PhoneVerificationConfirmCommand.of(
+                                emailFindConfirmCommand.verificationId(),
+                                emailFindConfirmCommand.code()));
+
+        Member member =
+                memberRepository.findByPhone(phoneVerification.getPhoneNumber())
+                        .orElseThrow(()-> new BadRequestException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return EmailFindConfirmResult.of(maskEmail(member.getEmail()));
+    }
+
+    private String maskEmail(String email) {
+        int atIndex = email.indexOf('@');
+        if (atIndex <= 0) {
+            return "**";
+        }
+
+        String localPart = email.substring(0, atIndex);
+        String domainPart = email.substring(atIndex + 1);
+
+        if (localPart.length() <= 2) {
+            return "**@" + domainPart;
+        }
+
+        String visiblePrefix = localPart.substring(0, 2);
+        return visiblePrefix + "**@" + domainPart;
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
@@ -3,30 +3,30 @@ package com.fliqo.service;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.fliqo.domain.entity.*;
-import com.fliqo.exception.BadRequestException;
-import com.fliqo.service.dto.request.EmailFindConfirmCommand;
-import com.fliqo.service.dto.request.PhoneVerificationConfirmCommand;
-import com.fliqo.service.dto.response.EmailFindConfirmResult;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fliqo.config.AuthProperties;
 import com.fliqo.controller.dto.response.TokenResponseDto;
+import com.fliqo.domain.entity.*;
 import com.fliqo.domain.repository.MemberCredentialRepository;
 import com.fliqo.domain.repository.MemberRepository;
+import com.fliqo.exception.BadRequestException;
 import com.fliqo.exception.ErrorCode;
 import com.fliqo.exception.UnauthorizedException;
 import com.fliqo.service.dto.request.EmailCheckCommand;
+import com.fliqo.service.dto.request.EmailFindConfirmCommand;
+import com.fliqo.service.dto.request.PhoneVerificationConfirmCommand;
 import com.fliqo.service.dto.request.SignupCommand;
 import com.fliqo.service.dto.response.EmailCheckResult;
+import com.fliqo.service.dto.response.EmailFindConfirmResult;
 import com.fliqo.service.dto.response.SignupResult;
 import com.fliqo.service.validator.MemberPolicyValidator;
 import com.fliqo.util.UuidUtil;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
@@ -107,25 +107,26 @@ public class MemberService {
      */
     private Member createMember(SignupCommand signupCmd) {
         log.info("=== Step 3 시작 ===");
-        Member member = Member.builder()
-                .memberUuid(UuidUtil.newUuid())
-                .email(signupCmd.email())
-                .name(signupCmd.name())
-                .phone(signupCmd.phoneNumber())
-                .role(Role.USER)
-                .status(MemberStatus.ACTIVE)
-                .emailVerified(false)
-                .phoneVerified(false)
-                .ownerVerified(false)
-                .onboardingStep((short) 0)
-                .locale("ko-KR")
-                .build();
+        Member member =
+                Member.builder()
+                        .memberUuid(UuidUtil.newUuid())
+                        .email(signupCmd.email())
+                        .name(signupCmd.name())
+                        .phone(signupCmd.phoneNumber())
+                        .role(Role.USER)
+                        .status(MemberStatus.ACTIVE)
+                        .emailVerified(false)
+                        .phoneVerified(false)
+                        .ownerVerified(false)
+                        .onboardingStep((short) 0)
+                        .locale("ko-KR")
+                        .build();
 
         log.info("Member 객체 생성 완료, 저장 시작...");
         Member savedMember = memberRepository.save(member);
         log.info("save() 호출 완료, ID: {}", savedMember.getId());
 
-        memberRepository.flush();  // ✅ 추가
+        memberRepository.flush(); // ✅ 추가
         log.info("flush() 완료, ID: {}", savedMember.getId());
 
         return savedMember;
@@ -154,13 +155,14 @@ public class MemberService {
         log.info("Password encoding 완료. 소요시간: {}ms", (endTime - startTime));
 
         log.info("MemberCredential 객체 생성 중...");
-        MemberCredential credential = MemberCredential.builder()
-                .member(member)
-                .passwordHash(hash)
-                .passwordAlgo(PasswordAlgo.BCRYPT)
-                .failedLoginAttempts(0)
-                .passwordChangedAt(LocalDateTime.now())
-                .build();
+        MemberCredential credential =
+                MemberCredential.builder()
+                        .member(member)
+                        .passwordHash(hash)
+                        .passwordAlgo(PasswordAlgo.BCRYPT)
+                        .failedLoginAttempts(0)
+                        .passwordChangedAt(LocalDateTime.now())
+                        .build();
         log.info("MemberCredential 객체 생성 완료");
 
         log.info("DB 저장 시작...");
@@ -258,7 +260,8 @@ public class MemberService {
     }
 
     @Transactional
-    public EmailFindConfirmResult emailFindByPhone(EmailFindConfirmCommand emailFindConfirmCommand) {
+    public EmailFindConfirmResult emailFindByPhone(
+            EmailFindConfirmCommand emailFindConfirmCommand) {
         PhoneVerification phoneVerification =
                 phoneVerificationService.verifyAndGet(
                         PhoneVerificationConfirmCommand.of(
@@ -266,8 +269,9 @@ public class MemberService {
                                 emailFindConfirmCommand.code()));
 
         Member member =
-                memberRepository.findByPhone(phoneVerification.getPhoneNumber())
-                        .orElseThrow(()-> new BadRequestException(ErrorCode.MEMBER_NOT_FOUND));
+                memberRepository
+                        .findByPhone(phoneVerification.getPhoneNumber())
+                        .orElseThrow(() -> new BadRequestException(ErrorCode.MEMBER_NOT_FOUND));
 
         return EmailFindConfirmResult.of(maskEmail(member.getEmail()));
     }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/PasswordResetService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/PasswordResetService.java
@@ -44,22 +44,27 @@ public class PasswordResetService {
             throw new BadRequestException(ErrorCode.RESET_INVALID_REQUEST);
         }
 
-        PhoneVerificationStartResult result =
+        PhoneVerificationStartResult phoneVerificationStartResult =
                 phoneVerificationService.start(
-                        PhoneVerificationStartCommand.of(passwordResetStartCmd.phoneNumber()));
-        return PasswordResetStartResult.of(result.verificationId(), result.expiresInMinutes());
+                        PhoneVerificationStartCommand.of(
+                                passwordResetStartCmd.phoneNumber(),
+                                passwordResetStartCmd.purpose()));
+        return PasswordResetStartResult.of(
+                phoneVerificationStartResult.verificationId(),
+                phoneVerificationStartResult.expiresInMinutes());
     }
 
     @Transactional
     public PasswordResetVerifyResult verify(PasswordResetVerifyCommand passwordResetVerifyCmd) {
-        PhoneVerificationConfirmResult confirmResult =
+        PhoneVerificationConfirmResult phoneVerificationConfirmResult =
                 phoneVerificationService.confirm(
                         PhoneVerificationConfirmCommand.of(
                                 passwordResetVerifyCmd.verificationId(),
                                 passwordResetVerifyCmd.code()));
 
         PhoneVerification phoneVerification =
-                phoneVerificationService.getByTokenOfThrow(confirmResult.verificationToken());
+                phoneVerificationService.getByTokenOfThrow(
+                        phoneVerificationConfirmResult.verificationToken());
 
         Member member =
                 memberRepository

--- a/fliqo-member-api/src/main/java/com/fliqo/service/PhoneVerificationService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/PhoneVerificationService.java
@@ -45,8 +45,12 @@ public class PhoneVerificationService {
             PhoneVerificationStartCommand phoneVerificationStartCmd) {
         // 인증 코드 생성 및 엔터티 생성
         String code = generateCode();
+
         PhoneVerification phoneVerification =
-                PhoneVerification.createNew(phoneVerificationStartCmd.phoneNumber(), code);
+                PhoneVerification.createNew(
+                        phoneVerificationStartCmd.phoneNumber(),
+                        code,
+                        phoneVerificationStartCmd.purpose());
 
         // 저장
         repository.save(phoneVerification);
@@ -65,18 +69,35 @@ public class PhoneVerificationService {
      * <p>세션 존재 여부 및 상태 검증은 {@link PhoneVerifyValidator}가 수행하며, 코드 일치/만료/시도 횟수 검증은 엔터티의 도메인
      * 로직({@link PhoneVerification#verify(String)})이 수행합니다.
      *
-     * @param phoneVerificationConfirmCmd 인증 세션 ID와 사용자 입력 코드를 담은 확인 명령
+     * @param phoneVerificationConfirmCommand 인증 세션 ID와 사용자 입력 코드를 담은 확인 명령
      * @return 검증 토큰을 담은 결과 객체
      */
     @Transactional
     public PhoneVerificationConfirmResult confirm(
-            PhoneVerificationConfirmCommand phoneVerificationConfirmCmd) {
-        PhoneVerification phoneVerification =
-                validator.mustExist(phoneVerificationConfirmCmd.verificationId());
-        phoneVerification.verify(phoneVerificationConfirmCmd.code());
-        repository.save(phoneVerification);
+            PhoneVerificationConfirmCommand phoneVerificationConfirmCommand) {
+        PhoneVerification phoneVerification = verifyAndGet(phoneVerificationConfirmCommand);
 
         return PhoneVerificationConfirmResult.of(phoneVerification.getVerificationToken());
+    }
+
+    /**
+     * 인증 코드를 검증하고 {@link PhoneVerification} 엔터티를 반환합니다.
+     *
+     * <p>주요 흐름은 {@link #confirm(PhoneVerificationConfirmCommand)}와 동일하며, 검증이 성공하면 엔터티를 그대로 돌려줍니다.
+     * 이메일 찾기 등 인증 이후 추가 정보가 필요한 시나리오에서 재사용하기 위한 유틸리티입니다.
+     *
+     * @param phoneVerificationConfirmCommand 인증 세션 ID와 사용자 입력 코드를 담은 확인 명령
+     * @return 검증이 완료된 {@link PhoneVerification}
+     */
+    @Transactional
+    public PhoneVerification verifyAndGet(
+            PhoneVerificationConfirmCommand phoneVerificationConfirmCommand) {
+        PhoneVerification phoneVerification =
+                validator.mustExist(phoneVerificationConfirmCommand.verificationId());
+        phoneVerification.verify(phoneVerificationConfirmCommand.code());
+        repository.save(phoneVerification);
+
+        return phoneVerification;
     }
 
     /**

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/EmailFindConfirmCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/EmailFindConfirmCommand.java
@@ -1,0 +1,15 @@
+package com.fliqo.service.dto.request;
+
+import lombok.Builder;
+
+public record EmailFindConfirmCommand(String verificationId, String code) {
+    @Builder
+    public EmailFindConfirmCommand {}
+
+    public static EmailFindConfirmCommand of(String verificationId, String code) {
+        return EmailFindConfirmCommand.builder()
+                .verificationId(verificationId)
+                .code(code)
+                .build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/EmailFindConfirmCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/EmailFindConfirmCommand.java
@@ -7,9 +7,6 @@ public record EmailFindConfirmCommand(String verificationId, String code) {
     public EmailFindConfirmCommand {}
 
     public static EmailFindConfirmCommand of(String verificationId, String code) {
-        return EmailFindConfirmCommand.builder()
-                .verificationId(verificationId)
-                .code(code)
-                .build();
+        return EmailFindConfirmCommand.builder().verificationId(verificationId).code(code).build();
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetStartCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PasswordResetStartCommand.java
@@ -1,10 +1,18 @@
 package com.fliqo.service.dto.request;
 
+import com.fliqo.domain.entity.PhoneVerificationPurpose;
+
 import lombok.Builder;
 
 @Builder
-public record PasswordResetStartCommand(String email, String phoneNumber) {
-    public static PasswordResetStartCommand of(String email, String phoneNumber) {
-        return PasswordResetStartCommand.builder().email(email).phoneNumber(phoneNumber).build();
+public record PasswordResetStartCommand(
+        String email, String phoneNumber, PhoneVerificationPurpose purpose) {
+    public static PasswordResetStartCommand of(
+            String email, String phoneNumber, PhoneVerificationPurpose purpose) {
+        return PasswordResetStartCommand.builder()
+                .email(email)
+                .phoneNumber(phoneNumber)
+                .purpose(purpose)
+                .build();
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PhoneVerificationStartCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/PhoneVerificationStartCommand.java
@@ -1,18 +1,26 @@
 package com.fliqo.service.dto.request;
 
+import com.fliqo.domain.entity.PhoneVerificationPurpose;
+
 import lombok.Builder;
 
 @Builder
-public record PhoneVerificationStartCommand(String phoneNumber) {
+public record PhoneVerificationStartCommand(String phoneNumber, PhoneVerificationPurpose purpose) {
     /**
      * 휴대폰 인증 요청(코드 발송)을 시작하기 위한 서비스 레이어 명령 객체를 생성합니다.
      *
-     * <p>{@code phoneNumber}는 서비스에서 요구하는 형식으로 전달되어야 합니다.
+     * <p>{@code phoneNumber, @code purpose}는 서비스에서 요구하는 형식으로 전달되어야 합니다.
      *
      * @param phoneNumber 인증 대상 휴대전화 번호(Null 허용 안 함)
+     * @param purpose 휴대폰 인증 목적(Null 허용 안 함)
      * @return {@link PhoneVerificationStartCommand} 인스턴스
      */
-    public static PhoneVerificationStartCommand of(String phoneNumber) {
-        return PhoneVerificationStartCommand.builder().phoneNumber(phoneNumber).build();
+    public static PhoneVerificationStartCommand of(
+            String phoneNumber, PhoneVerificationPurpose purpose) {
+
+        return PhoneVerificationStartCommand.builder()
+                .phoneNumber(phoneNumber)
+                .purpose(purpose)
+                .build();
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/EmailFindConfirmResult.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/EmailFindConfirmResult.java
@@ -1,0 +1,14 @@
+package com.fliqo.service.dto.response;
+
+import lombok.Builder;
+
+public record EmailFindConfirmResult(String maskedEmail) {
+    @Builder
+    public EmailFindConfirmResult {}
+
+    public static EmailFindConfirmResult of(String maskedEmail) {
+        return EmailFindConfirmResult.builder()
+                .maskedEmail(maskedEmail)
+                .build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/EmailFindConfirmResult.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/response/EmailFindConfirmResult.java
@@ -7,8 +7,6 @@ public record EmailFindConfirmResult(String maskedEmail) {
     public EmailFindConfirmResult {}
 
     public static EmailFindConfirmResult of(String maskedEmail) {
-        return EmailFindConfirmResult.builder()
-                .maskedEmail(maskedEmail)
-                .build();
+        return EmailFindConfirmResult.builder().maskedEmail(maskedEmail).build();
     }
 }


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 휴대전화 인증 완료 후, 해당 번호로 가입된 회원의 이메일을 조회하는 이메일 찾기 API를 구현했습니다.
- 휴대폰 인증 로직에 purpose(목적) 개념을 도입하여 회원가입/비밀번호 찾기/이메일 찾기를 목적별로 명확히 구분하도록 리팩토링했습니다.
- 인증 토큰을 기반으로 유효한 인증인지 검증 후, 이메일을 마스킹하여 반환합니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
1. 이메일 찾기 API 추가
- 휴대폰 인증 완료 후, 해당 번호로 가입된 회원 이메일을 반환하는 비즈니스 로직 추가
  - `EmailFindConfirmCommand`, `EmailFindConfirmResult` 등 서비스 레이어 DTO 추가
  - Controller 레이어에 `/email/find/request`, `/email/find/confirm' 엔드포인트 추가
- 인증 토큰(`verificationToken`)을 기반으로 아래 조건 검증
  - 유효한 토큰인지 (존재 여부)
  - 만료 시간 초과 여부
  - 이미 사용된 토큰인지 여부
  - purpose가 FIND_EMAIL 인지 여부
- 검증 완료 시
  - 인증 정보에 저장된 `phoneNumber`로 'Member' 조회
  - 조회된 이메일을 마스킹 처리 후 `EmailFindConfirmResult`로 반환

2. 휴대폰 인증 purpose 도입 및 기존 기능 리팩토링
- `PhoneVerificationPurpose` Enum 도입
  - `SIGNUP`, `PASSWORD_RESET`, `EMAIL_FIND`
- DB 스키마 변경 : `tb_phone_verification` 테이블에 'purpose' 컬럼 추가
- 기존 기능 리팩토링
  - 회원가입 휴대폰 인증 시
  - 비밀번호 찾기 휴대폰 인증 요청 시
  - 이메일 찾기 휴대폰 인증 요청 시
 
## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1.휴대전화, 목적(FIND_EMAIL) 작성 후 `/email/find/request` 엔드포인트 호출
4. `verificationId`, `code` 작성 후 `/email/find/confirm` 엔드포인트 호출
5. 해당 휴대폰으로 가입된 이메일이 마스킹(`e***@gmail.com`) 처리되어 반환되는지 확인

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #45 
