### PR TITLE
회원가입 시 약관 동의 저장 기능 추가

### DIFF
--- a/fliqo-common/src/main/java/com/fliqo/exception/ErrorCode.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/ErrorCode.java
@@ -42,6 +42,11 @@ public enum ErrorCode {
     PHONE_VERIFY_PHONE_MISMATCH(
             HttpStatus.BAD_REQUEST, "PHONE_007", "인증된 휴대폰 번호와 제출된 번호가 일치하지 않습니다."),
 
+    // ===== Terms Agreement (약관 동의) =====
+    TERMS_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST, "TERMS_001", "존재하지 않는 약관 코드입니다."),
+    TERMS_REQUIRED_NOT_AGREED(HttpStatus.BAD_REQUEST, "TERMS_002", "필수 약관에 동의하지 않았습니다."),
+    TERMS_MISSING_AGREEMENTS(HttpStatus.BAD_REQUEST, "TERMS_003", "약관 동의 정보가 누락되었습니다."),
+
     // ===== password reset =====
     RESET_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "RESET_001", "회원 정보를 찾을 수 없습니다."),
     RESET_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "RESET_002", "비밀번호 재설정 토큰이 유효하지 않습니다."),

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/MemberController.java
@@ -71,15 +71,7 @@ public class MemberController {
         memberPolicyValidator.validateOrThrow(
                 signupRequest.password(), signupRequest.passwordConfirm());
 
-        SignupResult signupResult =
-                memberService.signup(
-                        SignupCommand.builder()
-                                .email(signupRequest.email())
-                                .rawPassword(signupRequest.password())
-                                .name(signupRequest.name())
-                                .phoneNumber(signupRequest.phoneNumber())
-                                .phoneVerificationToken(signupRequest.phoneVerificationToken())
-                                .build());
+        SignupResult signupResult = memberService.signup(signupRequest.toCommand());
 
         return ResponseEntity.ok(
                 CommonResponse.success(

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/SignupRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/SignupRequest.java
@@ -1,5 +1,10 @@
 package com.fliqo.controller.dto.request;
 
+import java.util.List;
+
+import com.fliqo.service.dto.request.SignupCommand;
+import com.fliqo.service.dto.request.TermsAgreementCommand;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
@@ -9,4 +14,21 @@ public record SignupRequest(
         @NotBlank String passwordConfirm,
         @NotBlank String name,
         @NotBlank String phoneNumber,
-        @NotBlank String phoneVerificationToken) {}
+        @NotBlank String phoneVerificationToken,
+        List<TermsAgreementRequest> agreements) {
+    public SignupCommand toCommand() {
+        return SignupCommand.builder()
+                .email(email)
+                .rawPassword(password)
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .phoneVerificationToken(phoneVerificationToken)
+                .agreements(
+                        agreements == null
+                                ? null
+                                : agreements.stream()
+                                        .map(a -> new TermsAgreementCommand(a.code(), a.agreed()))
+                                        .toList())
+                .build();
+    }
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/TermsAgreementRequest.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/controller/dto/request/TermsAgreementRequest.java
@@ -1,0 +1,3 @@
+package com.fliqo.controller.dto.request;
+
+public record TermsAgreementRequest(String code, boolean agreed) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/entity/MemberTermsAgreement.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/entity/MemberTermsAgreement.java
@@ -1,0 +1,51 @@
+package com.fliqo.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(
+        name = "tb_member_terms_agreement",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_member_terms_version",
+                        columnNames = {"member_id", "terms_id", "agreed_version"}
+                )
+        }
+)
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTermsAgreement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "terms_id", nullable = false)
+    private Terms terms;
+
+    @Column(name = "agreed_version", nullable = false)
+    private Integer agreedVersion;
+
+    @Column(name = "agreed", nullable = false)
+    private Boolean agreed;
+
+    @Column(name = "agreed_at", nullable = false)
+    private LocalDateTime agreedAt;
+
+    @Column(name = "ip", length = 100)
+    private String ip;
+
+    @Column(name = "user_agent")
+    private String userAgent;
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/entity/MemberTermsAgreement.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/entity/MemberTermsAgreement.java
@@ -1,21 +1,18 @@
 package com.fliqo.domain.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 
 @Entity
 @Table(
         name = "tb_member_terms_agreement",
         uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "uk_member_terms_version",
-                        columnNames = {"member_id", "terms_id", "agreed_version"}
-                )
-        }
-)
+            @UniqueConstraint(
+                    name = "uk_member_terms_version",
+                    columnNames = {"member_id", "terms_id", "agreed_version"})
+        })
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/entity/Terms.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/entity/Terms.java
@@ -1,8 +1,9 @@
 package com.fliqo.domain.entity;
 
+import org.hibernate.annotations.Immutable;
+
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.Immutable;
 
 @Entity
 @Table(name = "tb_terms")

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/entity/Terms.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/entity/Terms.java
@@ -1,0 +1,34 @@
+package com.fliqo.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Immutable;
+
+@Entity
+@Table(name = "tb_terms")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Immutable
+public class Terms {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, length = 50)
+    private String code;
+
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title;
+
+    @Column(name = "required", nullable = false)
+    private Boolean required;
+
+    @Column(name = "content", columnDefinition = "text", nullable = false)
+    private String content;
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/repository/MemberTermsAgreementRepository.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/repository/MemberTermsAgreementRepository.java
@@ -1,0 +1,7 @@
+package com.fliqo.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.fliqo.domain.entity.MemberTermsAgreement;
+
+public interface MemberTermsAgreementRepository extends JpaRepository<MemberTermsAgreement, Long> {}

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/repository/TermsRepository.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/repository/TermsRepository.java
@@ -1,0 +1,12 @@
+package com.fliqo.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.fliqo.domain.entity.Terms;
+
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+
+    Optional<Terms> findTopByCodeOrderByVersionDesc(String code);
+}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
@@ -12,13 +12,12 @@ import com.fliqo.controller.dto.response.TokenResponseDto;
 import com.fliqo.domain.entity.*;
 import com.fliqo.domain.repository.MemberCredentialRepository;
 import com.fliqo.domain.repository.MemberRepository;
+import com.fliqo.domain.repository.MemberTermsAgreementRepository;
+import com.fliqo.domain.repository.TermsRepository;
 import com.fliqo.exception.BadRequestException;
 import com.fliqo.exception.ErrorCode;
 import com.fliqo.exception.UnauthorizedException;
-import com.fliqo.service.dto.request.EmailCheckCommand;
-import com.fliqo.service.dto.request.EmailFindConfirmCommand;
-import com.fliqo.service.dto.request.PhoneVerificationConfirmCommand;
-import com.fliqo.service.dto.request.SignupCommand;
+import com.fliqo.service.dto.request.*;
 import com.fliqo.service.dto.response.EmailCheckResult;
 import com.fliqo.service.dto.response.EmailFindConfirmResult;
 import com.fliqo.service.dto.response.SignupResult;
@@ -39,6 +38,8 @@ public class MemberService {
     private final MemberPolicyValidator memberPolicyValidator;
     private final JwtService jwtService;
     private final AuthProperties authProperties;
+    private final TermsRepository termsRepository;
+    private final MemberTermsAgreementRepository memberTermsAgreementRepository;
 
     @Transactional(readOnly = true)
     public EmailCheckResult checkEmail(EmailCheckCommand emailCheckCmd) {
@@ -60,6 +61,8 @@ public class MemberService {
         PhoneVerification phoneVerification = verifyPhone(signupCmd);
         Member member = createMember(signupCmd);
         createCredential(member, signupCmd.rawPassword());
+
+        saveTermsAgreements(member, signupCmd);
         phoneVerificationService.consumeToken(phoneVerification);
 
         return buildSignupResult(member);
@@ -104,8 +107,8 @@ public class MemberService {
                         .phone(signupCmd.phoneNumber())
                         .role(Role.USER)
                         .status(MemberStatus.ACTIVE)
-                        .emailVerified(false)
-                        .phoneVerified(false)
+                        .emailVerified(true)
+                        .phoneVerified(true)
                         .ownerVerified(false)
                         .onboardingStep((short) 0)
                         .locale("ko-KR")
@@ -260,5 +263,68 @@ public class MemberService {
 
         String visiblePrefix = localPart.substring(0, 2);
         return visiblePrefix + "**@" + domainPart;
+    }
+
+    /**
+     * 회원가입 시 약관 동의 이력을 저장합니다.
+     *
+     * @param member 생성된 회원
+     * @param signupCmd 회원가입 커맨드 (약관 동의 정보 포함)
+     */
+    private void saveTermsAgreements(Member member, SignupCommand signupCmd) {
+        List<TermsAgreementCommand> agreements = signupCmd.agreements();
+        if (agreements == null || agreements.isEmpty()) {
+            return; // 약관 동의 정보가 없으면 아무 것도 하지 않음
+        }
+
+        // ✅ 개발 단계: tb_terms 에 약관 데이터가 하나도 없으면 스킵
+        /*
+        if (termsRepository.count() == 0) {
+            log.warn(
+                    "회원가입 약관 저장을 스킵합니다. tb_terms 에 등록된 약관 데이터가 없습니다. memberId={}",
+                    member.getId());
+            return;
+        }
+         */
+
+        LocalDateTime now = LocalDateTime.now();
+
+        for (TermsAgreementCommand agreementCommand : agreements) {
+
+            // 1) code 기준 최신 약관 조회
+            Terms latest =
+                    termsRepository
+                            .findTopByCodeOrderByVersionDesc(agreementCommand.code())
+                            .orElse(null);
+
+            // ✅ 해당 code 에 대한 약관이 아직 등록되지 않은 경우: 스킵 (개발 편의용)
+            if (latest == null) {
+                log.warn(
+                        "약관 동의 저장을 스킵합니다. code 에 해당하는 약관이 없습니다. code={}, memberId={}",
+                        agreementCommand.code(),
+                        member.getId());
+                continue;
+            }
+
+            // 2) 필수 약관인데 동의하지 않으면 예외
+            //    (tb_terms 에 데이터가 존재하는 환경에서만 실제로 강제됨)
+            if (Boolean.TRUE.equals(latest.getRequired()) && !agreementCommand.agreed()) {
+                throw new BadRequestException(ErrorCode.TERMS_REQUIRED_NOT_AGREED);
+            }
+
+            // 3) 동의 이력 엔티티 생성
+            MemberTermsAgreement agreement =
+                    MemberTermsAgreement.builder()
+                            .member(member)
+                            .terms(latest)
+                            .agreedVersion(latest.getVersion())
+                            .agreed(agreementCommand.agreed())
+                            .agreedAt(now)
+                            // ip / userAgent 는 지금은 null, 나중에 컨트롤러에서 받아서 넣으면 됨
+                            .build();
+
+            // 4) 저장
+            memberTermsAgreementRepository.save(agreement);
+        }
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
@@ -285,8 +285,8 @@ public class MemberService {
             Terms latest =
                     termsRepository
                             .findTopByCodeOrderByVersionDesc(agreementCommand.code())
-                            .orElseThrow(()->
-                                    new BadRequestException(ErrorCode.TERMS_CODE_NOT_FOUND));
+                            .orElseThrow(
+                                    () -> new BadRequestException(ErrorCode.TERMS_CODE_NOT_FOUND));
 
             // 2) 필수 약관인데 동의하지 않으면 예외
             //    (tb_terms 에 데이터가 존재하는 환경에서만 실제로 강제됨)

--- a/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/MemberService.java
@@ -274,18 +274,8 @@ public class MemberService {
     private void saveTermsAgreements(Member member, SignupCommand signupCmd) {
         List<TermsAgreementCommand> agreements = signupCmd.agreements();
         if (agreements == null || agreements.isEmpty()) {
-            return; // 약관 동의 정보가 없으면 아무 것도 하지 않음
+            throw new BadRequestException(ErrorCode.TERMS_MISSING_AGREEMENTS);
         }
-
-        // ✅ 개발 단계: tb_terms 에 약관 데이터가 하나도 없으면 스킵
-        /*
-        if (termsRepository.count() == 0) {
-            log.warn(
-                    "회원가입 약관 저장을 스킵합니다. tb_terms 에 등록된 약관 데이터가 없습니다. memberId={}",
-                    member.getId());
-            return;
-        }
-         */
 
         LocalDateTime now = LocalDateTime.now();
 
@@ -295,16 +285,8 @@ public class MemberService {
             Terms latest =
                     termsRepository
                             .findTopByCodeOrderByVersionDesc(agreementCommand.code())
-                            .orElse(null);
-
-            // ✅ 해당 code 에 대한 약관이 아직 등록되지 않은 경우: 스킵 (개발 편의용)
-            if (latest == null) {
-                log.warn(
-                        "약관 동의 저장을 스킵합니다. code 에 해당하는 약관이 없습니다. code={}, memberId={}",
-                        agreementCommand.code(),
-                        member.getId());
-                continue;
-            }
+                            .orElseThrow(()->
+                                    new BadRequestException(ErrorCode.TERMS_CODE_NOT_FOUND));
 
             // 2) 필수 약관인데 동의하지 않으면 예외
             //    (tb_terms 에 데이터가 존재하는 환경에서만 실제로 강제됨)

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/SignupCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/SignupCommand.java
@@ -1,5 +1,7 @@
 package com.fliqo.service.dto.request;
 
+import java.util.List;
+
 import lombok.Builder;
 
 @Builder
@@ -8,4 +10,5 @@ public record SignupCommand(
         String rawPassword,
         String name,
         String phoneNumber,
-        String phoneVerificationToken) {}
+        String phoneVerificationToken,
+        List<TermsAgreementCommand> agreements) {}

--- a/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/TermsAgreementCommand.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/dto/request/TermsAgreementCommand.java
@@ -1,0 +1,3 @@
+package com.fliqo.service.dto.request;
+
+public record TermsAgreementCommand(String code, boolean agreed) {}


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- 회원가입 시 약관 동의 정보를 저장하는 기능을 추가했습니다.
- 필수 약관 검증, 약관 코드 존재 여부 검증, DB 최신 버전 약관 매핑 기능을 구현했습니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
1) 회원가입 시 약관 동의 저장 기능 추가
- 'SignupCommand'에 포함된 'agreements' 정보를 기반으로 약관 동의 이력('tb_member_terms_agreement') 저장
- 'TermsRepository.findTopByCodeOrderByVersionDesc()'를 이용하여 최신 버전 약관 매핑

2) 필수 약관 검증 로직 추가
- 필수(required=true)인데 agreed=false인 경우
→ TERMS_REQUIRED_NOT_AGREED 예외 발생

3) 약관 코드 유효성 검증 강화
- DB에 존재하지 않는 약관 code 전달 시
→ TERMS_CODE_NOT_FOUND 예외 발생하도록 수정

4) 약관 동의 정보 누락 검증 추가
- agreements 전체가 null 또는 empty일 경우
→ TERMS_MISSING_AGREEMENTS 예외 발생

5) MemberService.saveTermsAgreements() 개선
- 기존 스킵 로직 제거 (개발 편의용)
- 운영 기준에 맞춰 반드시 동의 정보를 검증하도록 변경
- 약관 버전은 최신 버전 자동 매핑 (현재는 mismatch 체크 제외)

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1. Swagger UI에서 회원가입 API 요청
2. 아래 요청을 보내고 정상 저장되는지 확인
``"agreements": [
  { "code": "SERVICE", "agreed": true },
  { "code": "PRIVACY", "agreed": true },
  { "code": "MARKETING", "agreed": false }
]
``
- DB `tb_member_terms_agreement` 테이블에 3건 저장 확인
3. 나머지 예외 건들 테스트
- 필수 약관 미동의 에러 : `TERMS_REQUIRED_NOT_AGREED`
- 존재하지 않는 코드 전달 : `TERMS_CODE_NOT_FOUND`
- agreements 누락 : `TERMS_MISSING_AGREEMENTS`

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #51 
