### PR TITLE
🐛 fix: 휴대폰 인증 시작 시 목적별 회원 존재 여부 검증 로직 적용

### DIFF
--- a/fliqo-common/src/main/java/com/fliqo/exception/ErrorCode.java
+++ b/fliqo-common/src/main/java/com/fliqo/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
             HttpStatus.BAD_REQUEST, "MEMBER_002", "비밀번호는 8자 이상이며 영문, 숫자, 특수문자를 모두 포함해야 합니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "MEMBER_003", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_004", "회원을 찾을 수 없습니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER_005", "이미 가입된 휴대폰 번호입니다."),
 
     // ===== Phone Verification (전화번호 인증) =====
     PHONE_VERIFY_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "PHONE_001", "유효하지 않은 인증 요청입니다."),

--- a/fliqo-member-api/src/main/java/com/fliqo/domain/repository/MemberRepository.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/domain/repository/MemberRepository.java
@@ -10,6 +10,8 @@ import com.fliqo.domain.entity.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
+    boolean existsByPhone(String phoneNumber);
+
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByPhone(String phone);

--- a/fliqo-member-api/src/main/java/com/fliqo/service/PhoneVerificationService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/PhoneVerificationService.java
@@ -2,6 +2,8 @@ package com.fliqo.service;
 
 import java.security.SecureRandom;
 
+import com.fliqo.domain.entity.PhoneVerificationPurpose;
+import com.fliqo.service.validator.MemberPolicyValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ public class PhoneVerificationService {
     private final PhoneVerificationRepository repository;
     private final SmsSender smsSender;
     private final PhoneVerifyValidator validator;
+    private final MemberPolicyValidator memberPolicyValidator;
 
     private static final int MAX_ATTEMPTS = 5;
 
@@ -43,6 +46,12 @@ public class PhoneVerificationService {
     @Transactional
     public PhoneVerificationStartResult start(
             PhoneVerificationStartCommand phoneVerificationStartCmd) {
+
+        String phoneNumber = phoneVerificationStartCmd.phoneNumber();
+        PhoneVerificationPurpose purpose = phoneVerificationStartCmd.purpose();
+
+        validatePhonePolicyByPurpose(phoneNumber, purpose);
+
         // 인증 코드 생성 및 엔터티 생성
         String code = generateCode();
 
@@ -122,5 +131,23 @@ public class PhoneVerificationService {
     public void consumeToken(PhoneVerification phoneVerification) {
         phoneVerification.consume();
         repository.save(phoneVerification);
+    }
+    /**
+     * 인증 목적에 따라 휴대폰 번호의 사용 가능 여부 및 가입 여부를 검증합니다.
+     *
+     * <ul>
+     *     <li>SIGNUP: 이미 가입된 번호면 예외</li>
+     *     <li>PASSWORD_RESET, FIND_EMAIL: 가입된 번호가 아니면 예외</li>
+     * </ul>
+     */
+    private void validatePhonePolicyByPurpose(String phoneNumber, PhoneVerificationPurpose purpose) {
+        switch (purpose) {
+            case SIGNUP -> {
+                memberPolicyValidator.ensurePhoneAvailableForSignup(phoneNumber);
+            }
+            case FIND_EMAIL, PASSWORD_RESET -> {
+                memberPolicyValidator.ensurePhoneAlreadyRegistered(phoneNumber);
+            }
+        }
     }
 }

--- a/fliqo-member-api/src/main/java/com/fliqo/service/PhoneVerificationService.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/PhoneVerificationService.java
@@ -2,17 +2,17 @@ package com.fliqo.service;
 
 import java.security.SecureRandom;
 
-import com.fliqo.domain.entity.PhoneVerificationPurpose;
-import com.fliqo.service.validator.MemberPolicyValidator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fliqo.domain.entity.PhoneVerification;
+import com.fliqo.domain.entity.PhoneVerificationPurpose;
 import com.fliqo.domain.repository.PhoneVerificationRepository;
 import com.fliqo.service.dto.request.PhoneVerificationConfirmCommand;
 import com.fliqo.service.dto.request.PhoneVerificationStartCommand;
 import com.fliqo.service.dto.response.PhoneVerificationConfirmResult;
 import com.fliqo.service.dto.response.PhoneVerificationStartResult;
+import com.fliqo.service.validator.MemberPolicyValidator;
 import com.fliqo.service.validator.PhoneVerifyValidator;
 
 import lombok.RequiredArgsConstructor;
@@ -132,15 +132,17 @@ public class PhoneVerificationService {
         phoneVerification.consume();
         repository.save(phoneVerification);
     }
+
     /**
      * 인증 목적에 따라 휴대폰 번호의 사용 가능 여부 및 가입 여부를 검증합니다.
      *
      * <ul>
-     *     <li>SIGNUP: 이미 가입된 번호면 예외</li>
-     *     <li>PASSWORD_RESET, FIND_EMAIL: 가입된 번호가 아니면 예외</li>
+     *   <li>SIGNUP: 이미 가입된 번호면 예외
+     *   <li>PASSWORD_RESET, FIND_EMAIL: 가입된 번호가 아니면 예외
      * </ul>
      */
-    private void validatePhonePolicyByPurpose(String phoneNumber, PhoneVerificationPurpose purpose) {
+    private void validatePhonePolicyByPurpose(
+            String phoneNumber, PhoneVerificationPurpose purpose) {
         switch (purpose) {
             case SIGNUP -> {
                 memberPolicyValidator.ensurePhoneAvailableForSignup(phoneNumber);

--- a/fliqo-member-api/src/main/java/com/fliqo/service/validator/MemberPolicyValidator.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/validator/MemberPolicyValidator.java
@@ -34,14 +34,13 @@ public class MemberPolicyValidator {
     /**
      * 회원가입 시 사용할 휴대폰 번호가 이미 등록되어 있지 않은지 검증합니다.
      *
-     * <p>이미 동일한 휴대폰 번호를 가진 회원이 존재하면
-     * {@link ErrorCode#MEMBER_ALREADY_EXISTS} 예외를 발생시켜 인증 절차를 중단합니다.
+     * <p>이미 동일한 휴대폰 번호를 가진 회원이 존재하면 {@link ErrorCode#MEMBER_ALREADY_EXISTS} 예외를 발생시켜 인증 절차를 중단합니다.
      *
      * @param phoneNumber 중복 여부를 확인할 휴대폰 번호
      * @throws BadRequestException 이미 가입된 번호인 경우
      */
     public void ensurePhoneAvailableForSignup(String phoneNumber) {
-        if(memberRepository.existsByPhone(phoneNumber)) {
+        if (memberRepository.existsByPhone(phoneNumber)) {
             throw new BadRequestException(ErrorCode.MEMBER_ALREADY_EXISTS);
         }
     }
@@ -59,6 +58,7 @@ public class MemberPolicyValidator {
             throw new BadRequestException(ErrorCode.MEMBER_NOT_FOUND);
         }
     }
+
     // 8자 이상, 영문+숫자+특수문자 각각 최소 1개
     private static final Pattern PWD =
             Pattern.compile(

--- a/fliqo-member-api/src/main/java/com/fliqo/service/validator/MemberPolicyValidator.java
+++ b/fliqo-member-api/src/main/java/com/fliqo/service/validator/MemberPolicyValidator.java
@@ -31,6 +31,34 @@ public class MemberPolicyValidator {
         }
     }
 
+    /**
+     * 회원가입 시 사용할 휴대폰 번호가 이미 등록되어 있지 않은지 검증합니다.
+     *
+     * <p>이미 동일한 휴대폰 번호를 가진 회원이 존재하면
+     * {@link ErrorCode#MEMBER_ALREADY_EXISTS} 예외를 발생시켜 인증 절차를 중단합니다.
+     *
+     * @param phoneNumber 중복 여부를 확인할 휴대폰 번호
+     * @throws BadRequestException 이미 가입된 번호인 경우
+     */
+    public void ensurePhoneAvailableForSignup(String phoneNumber) {
+        if(memberRepository.existsByPhone(phoneNumber)) {
+            throw new BadRequestException(ErrorCode.MEMBER_ALREADY_EXISTS);
+        }
+    }
+
+    /**
+     * 비밀번호 찾기/이메일 찾기 등, 휴대폰 번호가 기등록 회원이어야 하는 경우 사용됩니다.
+     *
+     * <p>해당 번호로 가입된 회원이 없으면 {@link ErrorCode#MEMBER_NOT_FOUND} 예외를 발생시킵니다.
+     *
+     * @param phoneNumber 가입 여부를 확인할 휴대폰 번호
+     * @throws BadRequestException 가입된 회원이 아닌 경우
+     */
+    public void ensurePhoneAlreadyRegistered(String phoneNumber) {
+        if (!memberRepository.existsByPhone(phoneNumber)) {
+            throw new BadRequestException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
     // 8자 이상, 영문+숫자+특수문자 각각 최소 1개
     private static final Pattern PWD =
             Pattern.compile(


### PR DESCRIPTION
## 📌 PR 개요
<!-- 이 PR이 무엇을 하는지 간단히 설명해주세요 -->
- SIGNUP 목적일 때 기존 가입된 휴대폰 번호에 대한 검증이 누락되어
이미 가입된 회원에게도 인증 코드와 verificationToken이 발급되는 문제를 수정했습니다.

회원가입(Signup) 목적의 휴대폰 인증은 기존 회원 여부를 반드시 검증해야 하므로,
MemberPolicyValidator를 통해 회원 존재 여부를 검증하도록 로직을 추가했습니다.

## 🔍 변경 사항
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->
- SIGNUP 목적의 휴대폰 인증 요청 시 회원 중복 검사 로직 추가
  - `MemberPolicyValidator.ensurePhoneAvailableForSignup(phoneNumber)` 호출
  - 기존 가입자일 경우 BadRequestException(MEMBER_ALREADY_EXISTS) 반환
- PASSWORD_RESET, FIND_EMAIL 등 다른 목적에 대한 정책도 명확히 분리
  - 기존 회원이어야 하는 목적에 대해 `ensurePhoneAlreadyRegistered` 적용
  - `start()` 메소드에 목적별 검증 로직 추가 (`validatePhonePolicyByPurpose`)

## 🧪 테스트 방법
<!-- 변경 사항이 제대로 작동하는지 테스트하는 방법을 작성해주세요 -->
1.이미 가입된 휴대폰 번호로 purpose = SIGNUP 설정 후 /phone-verification/start 호출
→ 400 Bad Request + MEMBER_ALREADY_EXISTS가 응답되는지 확인

2. 가입되지 않은 번호로 SIGNUP 요청 시
→ 인증 세션 정상 생성 + SMS 발송 + verificationToken 발급

3. PASSWORD_RESET, FIND_EMAIL 목적의 요청 시
→ 기존 가입된 번호만 인증 시작 가능 여부 확인

4. 수정된 로직에 대한 단위 테스트 / 통합 테스트 통과 확인

## 📎 참고 이슈
<!-- 관련된 이슈 번호를 연결해주세요 (예: #123) -->
Ref: #53 
